### PR TITLE
feat(Android): 升级 CallKit SDK 至 4.1.0，重构通话 UI 架构

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ local.properties
 /flutter_module/.ios/
 **/pubspec.lock
 .ccls-cache/
+
+# Signing certificates
+signing/

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -12,6 +12,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode Integer.parseInt(VERSION_CODE)
         versionName VERSION_NAME
+        multiDexEnabled true
 
         ndk {
             rootProject.ext.ndkAbis.each { abi ->
@@ -59,14 +60,22 @@ android {
 }
 
 dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation libs.androidx.appcompat
     implementation libs.androidx.constraintlayout
     implementation libs.glide
     implementation libs.androidx.recyclerview
+    implementation 'androidx.multidex:multidex:2.0.1'
     implementation libs.okhttp
-    implementation libs.okhttp.logging.interceptor
     implementation libs.retrofit.core
     implementation libs.retrofit.converter.gson
-//    implementation project(':call-ui')
-     implementation 'com.netease.yunxin.kit.call:call-ui:3.8.0'
+    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.netease.yunxin:nertc-nenn:5.9.10'
+    implementation 'com.netease.yunxin:nertc-segment:5.9.10'
+    implementation 'com.netease.yunxin.kit.hawk:hawk:1.7.13'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.5.1'
+    implementation 'com.netease.yunxin.kit.call:call-ui:4.1.0'
 }

--- a/Android/app/proguard-rules.pro
+++ b/Android/app/proguard-rules.pro
@@ -1,6 +1,6 @@
 # Add project specific ProGuard rules here.
 # You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+# proguardFiles setting in build.gradle.kts.
 #
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
@@ -19,30 +19,117 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
-
--dontwarn com.netease.nim.**
--keep class com.netease.nim.** {*;}
-
--dontwarn com.netease.nimlib.**
--keep class com.netease.nimlib.** {*;}
-
--dontwarn com.netease.share.**
--keep class com.netease.share.** {*;}
-
--dontwarn com.netease.mobsec.**
--keep class com.netease.mobsec.** {*;}
-
--keep class com.netease.lava.** {*;}
--keep class com.netease.yunxin.** {*;}
--keep class com.netease.compiler.** {*;}
--keep class com.huawei.multimedia.** {*;}
-
--dontwarn com.netease.yunxin.kit.**
--keep class com.netease.yunxin.kit.** {*;}
 -keep public class * extends com.netease.yunxin.kit.corekit.XKitInitOptions
--keep class * implements com.netease.yunxin.kit.corekit.XKitService {*;}
 
-# R8 missing classes rules - generated automatically
--dontwarn com.huawei.multimedia.**
--dontwarn com.netease.compiler.**
--dontwarn org.ahocorasick.trie.Trie
+-dontwarn com.netease.**
+-keep class com.netease.** {*;}
+
+#如果你使用全文检索插件，需要加入
+-dontwarn org.apache.lucene.**
+-keep class org.apache.lucene.** {*;}
+
+#如果你开启数据库功能，需要加入
+-keep class net.sqlcipher.** {*;}
+
+-keep class com.google.android.material.** {*;}
+
+-keep class androidx.** {*;}
+
+-keep public class * extends androidx.**
+
+-keep interface androidx.** {*;}
+
+-dontwarn com.google.android.material.**
+
+-dontnote com.google.android.material.**
+
+-dontwarn androidx.**
+
+### APP 3rd party jars(xiaomi push)
+-dontwarn com.xiaomi.push.**
+-keep class com.xiaomi.** {*;}
+
+### APP 3rd party jars(huawei push)
+-ignorewarnings
+-keepattributes *Annotation*
+-keepattributes Exceptions
+-keepattributes InnerClasses
+-keepattributes Signature
+-keepattributes SourceFile,LineNumberTable
+# hmscore-support: remote transport
+-keep class com.huawei.hianalytics.**{*;}
+-keep class com.huawei.updatesdk.**{*;}
+-keep class com.huawei.hms.**{*;}
+
+### APP 3rd party jars(meizu push)
+-dontwarn com.meizu.cloud.**
+-keep class com.meizu.cloud.** {*;}
+
+#vivo
+-dontwarn com.vivo.push.**
+-keep class com.vivo.push.** {*;}
+-keep class com.vivo.vms.** {*;}
+-keep class com.netease.nimlib.mixpush.vivo.VivoPushReceiver {*;}
+
+#oppo
+-keep public class * extends android.app.Service
+-keep class com.heytap.msp.** { *;}
+
+### APP 3rd party jars(glide)
+-keep public class * implements com.bumptech.glide.module.GlideModule
+-keep public enum com.bumptech.glide.load.resource.bitmap.ImageHeaderParser$** {
+  **[] $VALUES;
+  public *;
+}
+
+### org.json xml
+-dontwarn org.json.**
+-keep class org.json.**{*;}
+
+#okhttp
+-dontwarn okhttp3.**
+-keep class okhttp3.**{*;}
+#okio
+-dontwarn okio.**
+-keep class okio.**{*;}
+
+### glide 4
+-keep public class * implements com.bumptech.glide.module.GlideModule
+-keep public class * extends com.bumptech.glide.module.AppGlideModule
+-keep public enum com.bumptech.glide.load.resource.bitmap.ImageHeaderParser$** {
+    **[] $VALUES;
+    public *;
+}
+
+
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+-keepclasseswithmembers class * {
+    public <init>(android.content.Context, android.util.AttributeSet);
+    public <init>(android.content.Context, android.util.AttributeSet, int);
+}
+
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+-keep class * implements android.os.Parcelable {
+  public static final android.os.Parcelable$Creator *;
+}
+
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}
+
+-keep class **.R$* {
+ *;
+
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/CallKitBaseCase.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/CallKitBaseCase.java
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall;
+
+import android.text.TextUtils;
+import android.util.Log;
+import com.netease.yunxin.app.videocall.base.TestHelper;
+import com.netease.yunxin.kit.integrationtest.base.AbsHandleIntegratedEvent;
+import com.netease.yunxin.kit.integrationtest.model.TestItem;
+
+public class CallKitBaseCase extends AbsHandleIntegratedEvent<TestItem> {
+  @Override
+  public boolean handle(TestItem testItem) throws Exception {
+    super.handle(testItem);
+    if (TextUtils.isEmpty(methodName)) {
+      return false;
+    }
+    Log.e("!!!!!!!", methodName);
+    return TestHelper.handleMethod(this, testItem);
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/CallKitTestLauncher.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/CallKitTestLauncher.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.netease.yunxin.app.videocall.base.BaseTestUtils;
+import com.netease.yunxin.app.videocall.base.TestHelper;
+import com.netease.yunxin.app.videocall.callkit.CallKitTestUtils;
+import com.netease.yunxin.kit.integrationtest.Hawk;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class CallKitTestLauncher {
+
+  @Rule
+  public ActivityScenarioRule<MainActivity> mainRuler =
+      new ActivityScenarioRule<>(MainActivity.class);
+
+  @Before
+  public void init() {
+
+    Hawk.getInstance().setContext(ApplicationProvider.getApplicationContext());
+    //业务线、版本、分支
+    Hawk.getInstance().setRequestInfo("callkitUI", BuildConfig.VERSION_NAME);
+    Hawk.getInstance().registerHandle(new CallKitTestParser());
+  }
+
+  @Test
+  public void test() {
+    TestHelper.registerClass(
+        UITestBaseForCallKit.class, BaseTestUtils.class, CallKitTestUtils.class);
+    Hawk.getInstance().start();
+    TestHelper.releaseAll();
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/CallKitTestParser.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/CallKitTestParser.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall;
+
+import com.netease.yunxin.kit.integrationtest.base.AbsHandleIntegratedEvent;
+import com.netease.yunxin.kit.integrationtest.model.TestItem;
+import com.netease.yunxin.kit.integrationtest.register.ManualParser;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CallKitTestParser implements ManualParser {
+  @Override
+  public List<AbsHandleIntegratedEvent<TestItem>> getHandleIntegratedEventList() {
+    // 点对点呼叫 触发登录
+    // 执行登录
+    //-------
+    // 点击 点对点呼叫 触发登录——2
+    // 执行登录 ——2
+    //-------
+    // 搜索
+    // 呼叫目标
+    //---------
+    // 等待 5s——2
+    // 接听——2
+    //----------
+    // 等待 15s
+    // 挂断
+    // 退出当前页面
+    // 登出
+    // 等待 15s——2
+    // 退出当前页面——2
+    // 登出——2
+    return handleCase(1);
+  }
+
+  private List<AbsHandleIntegratedEvent<TestItem>> handleCase(int caseCount) {
+    List<AbsHandleIntegratedEvent<TestItem>> list = new ArrayList<>(caseCount);
+    for (int i = 0; i < caseCount; i++) {
+      list.add(new CallKitBaseCase());
+    }
+    return list;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/UITestBaseForCallKit.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/UITestBaseForCallKit.java
@@ -1,0 +1,120 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall;
+
+import static androidx.test.espresso.Espresso.pressBack;
+import static com.netease.yunxin.app.videocall.base.BaseTestUtils.waitForTime;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickEndCallOption;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickLogoutOption;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickNextBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickP2PItem;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickRecentByIndex;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickRecordByIndex;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickSearchBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickSearchResult;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickSendBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickUserAvatar;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.inputLoginPhone;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.inputSearchPhone;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.inputVerifyCode;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import com.netease.yunxin.app.videocall.base.ClassRegister;
+import com.netease.yunxin.nertc.nertcvideocall.model.NERTCVideoCall;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+@ClassRegister
+public class UITestBaseForCallKit {
+
+  @Rule
+  public ActivityScenarioRule<MainActivity> mainRuler =
+      new ActivityScenarioRule<>(MainActivity.class);
+
+  /**
+   * 进入登录页面并登录成功
+   *
+   * @param phoneNum 登录手机号
+   * @param verifyCode 验证码
+   */
+  public static void homeToLogin(String phoneNum, String verifyCode) {
+    inputLoginPhone(phoneNum);
+    clickSendBtn();
+    waitForTime(500);
+    inputVerifyCode(verifyCode);
+    clickNextBtn();
+    waitForTime(500);
+    NERTCVideoCall.sharedInstance().enableSwitchCallTypeConfirm(false, false);
+  }
+
+  /** 点击首页头像，弹出退出弹窗，退出 */
+  public static void homeToLogout() {
+    clickUserAvatar();
+    clickLogoutOption(true);
+    waitForTime(2000);
+  }
+
+  /** 强制退出当前通话 */
+  public static void forceEndCall() {
+    pressBack();
+    clickEndCallOption(true);
+  }
+
+  /** 进入 1对1 呼叫搜索页面 */
+  public static void enterP2PCall() {
+    clickP2PItem();
+  }
+
+  /**
+   * 搜索 手机号码
+   *
+   * @param phoneNum 手机号
+   */
+  public static void searchByPhone(String phoneNum) {
+    inputSearchPhone(phoneNum);
+    clickSearchBtn();
+  }
+
+  /**
+   * 开始呼叫搜索结果
+   *
+   * @param phoneNumResult 手机号结果目标
+   */
+  public static void startCallFromSearchResult(String phoneNumResult) {
+    clickSearchResult(phoneNumResult);
+  }
+
+  /**
+   * 通过 index 指定最近搜索记录发起呼叫
+   *
+   * @param index 索引 （0-2）
+   */
+  public static void startCallFromRecent(int index) {
+    clickRecentByIndex(index);
+  }
+
+  /**
+   * 通过 index 指定通话记录发起呼叫
+   *
+   * @param index 索引（0-2）
+   */
+  public static void startCallFromRecord(int index) {
+    clickRecordByIndex(index);
+  }
+
+  /**
+   * 配置通话转换确认
+   *
+   * @param audio2Video true 音频转视频需要确认，false 音频转视频不需要确认；
+   * @param video2Audio true 视频转音频需要确认，false 视频转音频不需要确认；
+   */
+  public static void enableSwitchCallTypeConfirm(boolean audio2Video, boolean video2Audio) {
+    NERTCVideoCall.sharedInstance().enableSwitchCallTypeConfirm(audio2Video, video2Audio);
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/UITestForCallee.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/UITestForCallee.java
@@ -1,0 +1,86 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall;
+
+import static androidx.test.espresso.Espresso.pressBack;
+import static com.netease.yunxin.app.videocall.base.BaseTestUtils.waitForTime;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkCalleeSwitchTypeWhenCallState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkCallerSwitchTypeWhenCallState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkMicroPhoneState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkMuteVideoState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkSpeakerState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkSwitchType;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickAcceptBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickCalleeSwitchTypeBtnWhenCall;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickCameraFlip;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickMicroPhoneBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickMuteVideoBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickRejectBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickSpeakerBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickSwitchTypeBtn;
+
+import com.netease.nimlib.sdk.avsignalling.constant.ChannelType;
+import org.junit.Test;
+
+public class UITestForCallee extends UITestBaseForCallKit {
+
+  @Test
+  public void testSelf() {
+    enterP2PCall();
+    homeToLogin("15725572857", "1111");
+    enterP2PCall();
+    calleeForAcceptCallUsual();
+    waitForTime(2000);
+    pressBack();
+    waitForTime(2000);
+    homeToLogout();
+  }
+
+  /** 主叫搜索目标用户并进行呼叫各种按钮切换测试及检验 */
+  public static void calleeForAcceptCallUsual() {
+    //----------- 等待呼叫 -----------
+    waitForTime(5000);
+    checkCalleeSwitchTypeWhenCallState(ChannelType.VIDEO.getValue());
+    clickCalleeSwitchTypeBtnWhenCall();
+    checkCalleeSwitchTypeWhenCallState(ChannelType.AUDIO.getValue());
+    clickCalleeSwitchTypeBtnWhenCall();
+    clickAcceptBtn();
+
+    checkSwitchType(ChannelType.VIDEO.getValue());
+    //----------- 等待主叫操作 ----------
+    waitForTime(10000);
+
+    clickCalleeSwitchTypeBtnWhenCall(); // audio
+    checkCallerSwitchTypeWhenCallState(ChannelType.AUDIO.getValue());
+    waitForTime(1000);
+    clickMicroPhoneBtn();
+    checkMicroPhoneState(false);
+    waitForTime(2000);
+    clickSpeakerBtn();
+    checkSpeakerState(true);
+
+    waitForTime(1000);
+    clickSpeakerBtn();
+    checkSpeakerState(false);
+    waitForTime(1000);
+    clickSwitchTypeBtn();
+    checkSwitchType(ChannelType.VIDEO.getValue());
+    waitForTime(1000);
+    clickMicroPhoneBtn();
+    checkMicroPhoneState(false);
+    waitForTime(1000);
+    clickMuteVideoBtn();
+    checkMuteVideoState(true);
+    waitForTime(1000);
+    clickCameraFlip();
+    waitForTime(2000);
+    clickCameraFlip();
+
+    // 通话结束
+    // 等待再次呼叫并拒绝
+    waitForTime(10000);
+    clickRejectBtn();
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/UITestForCaller.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/UITestForCaller.java
@@ -1,0 +1,103 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall;
+
+import static androidx.test.espresso.Espresso.pressBack;
+import static com.netease.yunxin.app.videocall.base.BaseTestUtils.waitForTime;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkCallerMicroPhoneWhenCallState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkCallerSpeakerWhenCallState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkCallerSwitchTypeWhenCallState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkMicroPhoneState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkMuteVideoState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkSpeakerState;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.checkSwitchType;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickCallerMicroPhoneBtnWhenCall;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickCallerSpeakerWhenCall;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickCallerSwitchTypeBtnWhenCall;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickCameraFlip;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickCancelBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickHangupBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickMicroPhoneBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickMuteVideoBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickSpeakerBtn;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestUtils.clickSwitchTypeBtn;
+
+import com.netease.nimlib.sdk.avsignalling.constant.ChannelType;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class UITestForCaller extends UITestBaseForCallKit {
+
+  @Test
+  public void testSelf() {
+    // 登录 case
+    enterP2PCall();
+    homeToLogin("15098918829", "1112");
+    enterP2PCall();
+    callerSearchAndCallUsual("15725572857");
+    waitForTime(2000);
+    pressBack();
+    waitForTime(2000);
+    homeToLogout();
+  }
+
+  /**
+   * 主叫搜索目标用户并进行呼叫各种按钮切换测试及检验
+   *
+   * @param phone 目标用户手机账号
+   */
+  public static Map<String, String> callerSearchAndCallUsual(String phone) {
+    searchByPhone(phone);
+    startCallFromSearchResult(phone); // video
+    waitForTime(500);
+    checkCallerSwitchTypeWhenCallState(ChannelType.VIDEO.getValue());
+    //--------- 呼叫页面 --------------
+    clickCallerSwitchTypeBtnWhenCall(); // audio
+    checkCallerSwitchTypeWhenCallState(ChannelType.AUDIO.getValue());
+    checkCallerMicroPhoneWhenCallState(true);
+    clickCallerMicroPhoneBtnWhenCall();
+    checkCallerMicroPhoneWhenCallState(false);
+    clickCallerMicroPhoneBtnWhenCall();
+    checkCallerSpeakerWhenCallState(false);
+    clickCallerSpeakerWhenCall();
+    checkCallerSpeakerWhenCallState(true);
+    clickCallerSpeakerWhenCall();
+
+    //--------- 等待对方接听 -----------
+    waitForTime(10000);
+
+    checkSwitchType(ChannelType.AUDIO.getValue()); //检查通话类型
+    clickMicroPhoneBtn();
+    checkMicroPhoneState(false);
+    clickSpeakerBtn();
+    checkSpeakerState(true);
+    clickSwitchTypeBtn(); // video
+    checkSwitchType(ChannelType.VIDEO.getValue());
+    clickMicroPhoneBtn();
+    checkMicroPhoneState(false);
+    clickMuteVideoBtn();
+    checkMuteVideoState(false);
+    clickMuteVideoBtn(); // true
+    clickCameraFlip();
+    waitForTime(2000);
+    clickCameraFlip();
+
+    //--------- 等待被叫检查操作 -----------
+    // 挂断
+    waitForTime(4000);
+    clickHangupBtn();
+
+    // 点击通话记录，被叫拒绝
+    startCallFromRecord(0);
+    waitForTime(5000);
+
+    // 点击最近搜索，主叫取消
+    startCallFromRecent(0);
+    clickCancelBtn();
+
+    return new HashMap<>();
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/android_ui_test.sh
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/android_ui_test.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Copyright (c) 2022 NetEase, Inc. All rights reserved.
+# Use of this source code is governed by a MIT license that can be
+# found in the LICENSE file.
+
+set -x
+# 自定义修改
+selectPartNameList=[\"Case1\"]
+platform="android"
+appId="1006"
+
+## 执行方式 ===========
+# sh android_ui_test.sh "callkit" "1.4.0" "PBV7N16A12000656" "UJK0220410050250"
+# "android1": "231129212745115",
+#  "android2": "875914692556114"
+# sh android_ui_test.sh "callkit" "1.3.4" "D5F7N18516008620" "UJK0220410050250"
+
+###########################################
+arr=$*
+params=($arr)
+
+adb="$HOME/Library/Android/sdk/platform-tools/adb"
+host="59.111.31.178"
+#host="10.242.148.84:9090"
+caseId=""
+echo "$adb"
+#$adb devices
+startRunning() {
+    for i in $arr; do
+      if [ "$i" == "" ]; then
+        echo "当前参数为空 $i "
+      else
+        adb -s "${i}" shell am instrument -w -m   -e debug false -e class 'com.netease.yunxin.app.videocall.CallKitTestLauncher' com.netease.yunxin.app.videocall.test/androidx.test.runner.AndroidJUnitRunner  &    echo "start running $i "
+      fi
+    done
+}
+
+# CI接口使用
+hasNextPart() {
+  result=$(curl "http://${host}:9000/hasNextPart?deviceId=156487853555010" \
+    -H 'Content-Type: application/json; charset=utf-8')
+
+  value=$(parse_json "$result" "currentIndex")
+  echo "$value"
+}
+
+# 默认支持两台设备，如果需要运行，需要注册手机设备@赵冲
+#  "selectPartNameList": [],
+dispatchDevice() {
+result=$(curl -X "PUT" "http://${host}/caseGroup/dispatch" \
+     -H 'Content-Type: application/json; charset=utf-8' \
+     -d $'{
+  "platform":"'${platform}'",
+  "selectPartNameList": '${selectPartNameList}',
+  "appId": "'${appId}'",
+  "version": "'${params[1]}'",
+  "deviceIdMap":  {
+    "android1": "'${params[2]}'",
+    "android2":  "'${params[3]}'"
+  },
+  "env": "'${params[0]}'"
+}')
+  # shellcheck disable=SC2034
+  taskId=$(parse_json "$result" "taskId")
+  echo "===>>>taskId"
+}
+sendFirst() {
+result=$(curl -X "POST" "http://${host}/push/start/$1/$2" \
+     -H 'Content-Type: application/json; charset=utf-8')
+   code=$(parse_json "$result" "code")
+   echo "====$code"
+}
+
+executeCase() {
+#  remoteIndex=$(hasNextPart)
+#    if [[ $remoteIndex == "-1" ]]; then
+#      sleep 3
+#      echo "当前没有需要执行的用例了"
+#      return
+#    fi
+    echo "***********exe nextPart start*********"
+    startRunning
+    echo "************exe nextPart end********"
+}
+
+parse_json(){
+echo "${1//\"/}" | sed "s/.*$2:\([^,}]*\).*/\1/"
+}
+
+executeCase
+sleep 6
+dispatchDevice
+sendFirst "$taskId"  "$caseId"
+echo "all is ending"
+

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitClassRegister.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitClassRegister.java
@@ -1,0 +1,158 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+import com.netease.nimlib.sdk.NIMClient;
+import com.netease.nimlib.sdk.auth.AuthService;
+import com.netease.nimlib.sdk.auth.AuthServiceObserver;
+import com.netease.nimlib.sdk.event.EventSubscribeService;
+import com.netease.nimlib.sdk.event.EventSubscribeServiceObserver;
+import com.netease.nimlib.sdk.friend.FriendService;
+import com.netease.nimlib.sdk.friend.FriendServiceObserve;
+import com.netease.nimlib.sdk.msg.MsgService;
+import com.netease.nimlib.sdk.msg.MsgServiceObserve;
+import com.netease.nimlib.sdk.msg.SystemMessageObserver;
+import com.netease.nimlib.sdk.msg.SystemMessageService;
+import com.netease.nimlib.sdk.nos.NosService;
+import com.netease.nimlib.sdk.nos.NosServiceObserve;
+import com.netease.nimlib.sdk.passthrough.PassthroughService;
+import com.netease.nimlib.sdk.passthrough.PassthroughServiceObserve;
+import com.netease.nimlib.sdk.team.TeamService;
+import com.netease.nimlib.sdk.team.TeamServiceObserver;
+import com.netease.nimlib.sdk.uinfo.UserService;
+import com.netease.yunxin.kit.call.group.NEGroupCall;
+import com.netease.yunxin.kit.call.p2p.NECallEngine;
+import com.netease.yunxin.kit.integrationtest.register.ClassRegister;
+import com.netease.yunxin.nertc.nertcvideocall.model.NERTCVideoCall;
+import java.util.HashMap;
+
+public class CallKitClassRegister implements ClassRegister {
+
+  /** 类Class映射表 */
+  private static HashMap<String, Class<?>> classHashMap =
+      new HashMap<String, Class<?>>() {
+        {
+          // SDK Service
+          put("AuthService", AuthService.class);
+          put("AuthServiceObserver", AuthServiceObserver.class);
+          put("EventSubscribeService", EventSubscribeService.class);
+          put("EventSubscribeServiceObserver", EventSubscribeServiceObserver.class);
+          put("FriendService", FriendService.class);
+          put("FriendServiceObserve", FriendServiceObserve.class);
+          put("MsgService", MsgService.class);
+          put("MsgServiceObserve", MsgServiceObserve.class);
+          put("SystemMessageService", SystemMessageService.class);
+          put("SystemMessageObserver", SystemMessageObserver.class);
+          put("NosService", NosService.class);
+          put("NosServiceObserve", NosServiceObserve.class);
+          put("PassthroughService", PassthroughService.class);
+          put("PassthroughServiceObserve", PassthroughServiceObserve.class);
+          put("TeamService", TeamService.class);
+          put("TeamServiceObserver", TeamServiceObserver.class);
+          put("UserService", UserService.class);
+          put("NERTCVideoCall", NERTCVideoCall.class);
+          put("NECallEngine", NECallEngine.class);
+          put("NEGroupCall", NEGroupCall.class);
+        }
+      };
+
+  @Override
+  public Class<?> getClass(String name) {
+    if (name == null || name.length() == 0) {
+      return null;
+    }
+
+    int index = name.indexOf("[]");
+    if (index < 0) {
+      return classHashMap.get(name);
+    }
+
+    String className = name.substring(0, index);
+    Class<?> aClass = classHashMap.get(className);
+    int lastIndex = name.lastIndexOf("[]");
+    int count = 1;
+    if (lastIndex > index) {
+      count = (lastIndex - index + 2) / 2;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < count; i++) {
+      sb.append("[");
+    }
+    sb.append(getClassDesciptor(aClass));
+    String arrayClassName = sb.toString();
+    try {
+      return Class.forName(arrayClassName);
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  /**
+   * 获取类型的描述符
+   *
+   * @param aClass
+   * @return
+   */
+  private static String getClassDesciptor(Class<?> aClass) {
+    if (aClass.equals(boolean.class)) {
+      return "Z";
+    } else if (aClass.equals(int.class)) {
+      return "I";
+    } else if (aClass.equals(long.class)) {
+      return "J";
+    } else if (aClass.equals(float.class)) {
+      return "F";
+    } else if (aClass.equals(double.class)) {
+      return "D";
+    } else if (aClass.equals(byte.class)) {
+      return "B";
+    } else if (aClass.equals(char.class)) {
+      return "C";
+    } else if (aClass.equals(short.class)) {
+      return "S";
+    } else {
+      return "L" + aClass.getName().replace('.', '/') + ";";
+    }
+  }
+
+  @Override
+  /** 通过类名获取对象 */
+  public Object getObject(String name) {
+
+    Class<?> clazz = null;
+    if (AuthService.class.getSimpleName().equals(name)) {
+      clazz = AuthService.class;
+    } else if (FriendService.class.getSimpleName().equals(name)) {
+      clazz = FriendService.class;
+    } else if (MsgService.class.getSimpleName().equals(name)) {
+      clazz = MsgService.class;
+    } else if (TeamService.class.getSimpleName().equals(name)) {
+      clazz = TeamService.class;
+    } else if (UserService.class.getSimpleName().equals(name)) {
+      clazz = UserService.class;
+    } else if (SystemMessageService.class.getSimpleName().equals(name)) {
+      clazz = SystemMessageService.class;
+    } else if (PassthroughService.class.getSimpleName().equals(name)) {
+      clazz = PassthroughService.class;
+    } else if (NosService.class.getSimpleName().equals(name)) {
+      clazz = NosService.class;
+    } else if (EventSubscribeService.class.getSimpleName().equals(name)) {
+      clazz = EventSubscribeService.class;
+    } else if (NERTCVideoCall.class.getSimpleName().equals(name)) {
+      return NERTCVideoCall.sharedInstance();
+    } else if (NECallEngine.class.getSimpleName().equals(name)) {
+      return NECallEngine.sharedInstance();
+    } else if (NEGroupCall.class.getSimpleName().equals(name)) {
+      return NEGroupCall.instance();
+    }
+
+    if (clazz != null) {
+      return NIMClient.getService(clazz);
+    } else {
+      return null;
+    }
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitInterceptor.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitInterceptor.java
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+import com.netease.nimlib.sdk.InvocationFuture;
+import com.netease.nimlib.sdk.RequestCallback;
+import com.netease.nimlib.sdk.ResponseCode;
+import com.netease.yunxin.kit.integrationtest.intercept.InterceptResultCallback;
+import com.netease.yunxin.kit.integrationtest.intercept.ResultInterceptor;
+import java.util.concurrent.CountDownLatch;
+
+public class CallKitInterceptor implements ResultInterceptor {
+
+  @Override
+  public boolean onIntercept(Object obj, InterceptResultCallback callback) {
+
+    if (obj instanceof InvocationFuture) {
+      CountDownLatch latch = new CountDownLatch(1);
+      ((InvocationFuture<Object>) obj)
+          .setCallback(
+              new RequestCallback<Object>() {
+                @Override
+                public void onSuccess(Object param) {
+                  callback.onResult(ResponseCode.RES_SUCCESS, "onSuccess", param);
+                  latch.countDown();
+                }
+
+                @Override
+                public void onFailed(int code) {
+                  callback.onResult(code, "onFailed", null);
+                  latch.countDown();
+                }
+
+                @Override
+                public void onException(Throwable exception) {
+                  callback.onResult(
+                      ResponseCode.RES_EXCEPTION, "onException " + exception.getMessage(), null);
+                  latch.countDown();
+                }
+              });
+
+      //      try {
+      //        if (!latch.await(30, TimeUnit.SECONDS)) {
+      //          callback.onResult(ResponseCode.RES_ETIMEOUT, "Time out", null);
+      //        }
+      //      } catch (InterruptedException e) {
+      //        e.printStackTrace();
+      //      }
+
+    } else {
+      //      callback.onResult(ResponseCode.RES_SUCCESS, "onSuccess", obj);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitParamsRegister.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitParamsRegister.java
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+import com.netease.nimlib.sdk.RequestCallback;
+import com.netease.yunxin.kit.call.NEResultObserver;
+import com.netease.yunxin.kit.call.p2p.model.NECallEngineDelegate;
+import com.netease.yunxin.kit.call.p2p.model.NERecordProvider;
+import com.netease.yunxin.kit.call.p2p.model.NESetupConfig;
+import com.netease.yunxin.kit.call.p2p.param.NECallParam;
+import com.netease.yunxin.kit.call.p2p.param.NEHangupParam;
+import com.netease.yunxin.kit.call.p2p.param.NESwitchParam;
+import com.netease.yunxin.kit.integrationtest.base.BaseParseAdapter;
+import com.netease.yunxin.kit.integrationtest.register.ParamsRegister;
+import com.netease.yunxin.nertc.nertcvideocall.model.JoinChannelCallBack;
+import com.netease.yunxin.nertc.nertcvideocall.model.NERTCCallingDelegate;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CallKitParamsRegister implements ParamsRegister {
+
+  @Override
+  /** 注册需要特殊解析的参数类型 */
+  public Set<Class<?>> getRegisterType() {
+    Set<Class<?>> set = new HashSet<>();
+    set.add(JoinChannelCallBack.class);
+    set.add(RequestCallback.class);
+    set.add(NERTCCallingDelegate.class);
+    set.add(NESetupConfig.class);
+    set.add(NECallParam.class);
+    set.add(NEHangupParam.class);
+    set.add(NESwitchParam.class);
+    set.add(NERecordProvider.class);
+    set.add(NECallEngineDelegate.class);
+    set.add(NEResultObserver.class);
+    return set;
+  }
+
+  @Override
+  /** 注册参数类型的解析适配器 */
+  public BaseParseAdapter<?> getParseAdapter() {
+    return new CallKitParseAdapter<>();
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitParseAdapter.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitParseAdapter.java
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.netease.yunxin.kit.integrationtest.Hawk;
+import com.netease.yunxin.kit.integrationtest.base.BaseParseAdapter;
+import java.lang.reflect.Type;
+
+public class CallKitParseAdapter<T> extends BaseParseAdapter<T> {
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public T deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    //            try {
+    if (typeOfT.getTypeName().contains("JoinChannelCallBack")) {
+      return (T) DataFactory.getInstance().joinChannelCallBack;
+    } else if (typeOfT.getTypeName().contains("RequestCallback")) {
+      return (T) DataFactory.getInstance().callback;
+    } else if (typeOfT.getTypeName().contains("NERTCCallingDelegate")) {
+      Hawk.getInstance().putListener(DataFactory.getInstance().nertcCallingDelegate);
+      return (T) DataFactory.getInstance().nertcCallingDelegate;
+    } else if (typeOfT.getTypeName().contains("NECallEngineDelegate")) {
+      Hawk.getInstance().putListener(DataFactory.getInstance().callEngineDelegate);
+      return (T) DataFactory.getInstance().callEngineDelegate;
+    } else if (typeOfT.getTypeName().contains("NERecordProvider")) {
+      return (T) DataFactory.getInstance().recordProvider;
+    } else if (typeOfT.getTypeName().contains("NEResultObserver")) {
+      return (T) DataFactory.getInstance().resultObserver;
+    }
+    //接口对创建meetingItem
+    //                else if (typeOfT.getTypeName().contains("NEMeetingItem"))
+    //                    return context.deserialize(json, Class.forName("com.netease.meetinglib.impl.model.MeetingItemImpl"));
+    //            } catch (ClassNotFoundException cnfe) {
+    //                throw new JsonParseException("Unknown element type");
+    //            }
+    return null;
+  }
+
+  @Override
+  public JsonElement serialize(Object src, Type typeOfSrc, JsonSerializationContext context) {
+    //            if (src instanceof NEMeetingItem)
+    //                return context.serialize(src, src.getClass());
+    return null;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitTestLauncher.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallKitTestLauncher.java
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+import android.os.Handler;
+import android.os.Looper;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.netease.yunxin.app.videocall.BuildConfig;
+import com.netease.yunxin.app.videocall.config.AppConfig;
+import com.netease.yunxin.kit.integrationtest.Hawk;
+import com.netease.yunxin.nertc.nertcvideocall.model.NERTCVideoCall;
+import com.netease.yunxin.nertc.nertcvideocall.model.VideoCallOptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
+ */
+@RunWith(AndroidJUnit4.class)
+public class CallKitTestLauncher {
+
+  @Before
+  public void init() {
+    new Handler(Looper.getMainLooper())
+        .post(
+            () -> {
+              // 注意：操作必须在主进程中进行
+              //              NIMClient.getService(AuthService.class).logout();
+
+              VideoCallOptions options = new VideoCallOptions(null);
+              options.enableAutoJoinWhenCalled = true;
+              NERTCVideoCall.sharedInstance()
+                  .setupAppKey(
+                      ApplicationProvider.getApplicationContext(), AppConfig.getAppKey(), options);
+              NERTCVideoCall.sharedInstance().setTimeOut(119999);
+              NERTCVideoCall.sharedInstance().enableSwitchCallTypeConfirm(false, false);
+            });
+    Hawk.getInstance().setContext(ApplicationProvider.getApplicationContext());
+    Hawk.getInstance().setRequestInfo("callkit", BuildConfig.VERSION_NAME);
+    Hawk.getInstance().registerClass(new CallKitClassRegister());
+    Hawk.getInstance().registerParams(new CallKitParamsRegister());
+    Hawk.getInstance().registerHandle(new CallbackManualParser());
+    Hawk.getInstance().setInterceptor(new CallKitInterceptor());
+  }
+
+  @Test
+  public void test() {
+    Hawk.getInstance().start();
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallbackManualParser.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/CallbackManualParser.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+import com.netease.yunxin.app.videocall.apitest.handlecase.HandleCallbackCase;
+import com.netease.yunxin.app.videocall.apitest.handlecase.LoginCase;
+import com.netease.yunxin.app.videocall.apitest.handlecase.NewInterfaceV2Case;
+import com.netease.yunxin.app.videocall.apitest.handlecase.RtcHelperCase;
+import com.netease.yunxin.kit.integrationtest.base.AbsHandleIntegratedEvent;
+import com.netease.yunxin.kit.integrationtest.model.TestItem;
+import com.netease.yunxin.kit.integrationtest.register.ManualParser;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CallbackManualParser implements ManualParser {
+  @Override
+  public List<AbsHandleIntegratedEvent<TestItem>> getHandleIntegratedEventList() {
+    List<AbsHandleIntegratedEvent<TestItem>> list = new ArrayList<>();
+    list.add(new HandleCallbackCase());
+    list.add(new LoginCase());
+    list.add(new NewInterfaceV2Case());
+    list.add(new RtcHelperCase());
+    return list;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/DataFactory.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/DataFactory.java
@@ -1,0 +1,278 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+import com.netease.nimlib.sdk.RequestCallback;
+import com.netease.nimlib.sdk.util.Entry;
+import com.netease.nimlib.sdk.v2.avsignalling.model.V2NIMSignallingRoomInfo;
+import com.netease.yunxin.kit.call.NEResultObserver;
+import com.netease.yunxin.kit.call.p2p.model.NECallEndInfo;
+import com.netease.yunxin.kit.call.p2p.model.NECallEngineDelegate;
+import com.netease.yunxin.kit.call.p2p.model.NECallInfo;
+import com.netease.yunxin.kit.call.p2p.model.NECallTypeChangeInfo;
+import com.netease.yunxin.kit.call.p2p.model.NEInviteInfo;
+import com.netease.yunxin.kit.call.p2p.model.NERecordProvider;
+import com.netease.yunxin.kit.integrationtest.Hawk;
+import com.netease.yunxin.nertc.nertcvideocall.bean.CommonResult;
+import com.netease.yunxin.nertc.nertcvideocall.bean.InvitedInfo;
+import com.netease.yunxin.nertc.nertcvideocall.model.JoinChannelCallBack;
+import com.netease.yunxin.nertc.nertcvideocall.model.NERTCCallingDelegate;
+import com.netease.yunxin.nertc.nertcvideocall.model.NERTCVideoCall;
+import com.netease.yunxin.nertc.nertcvideocall.model.impl.NERtcCallbackExTemp;
+import com.netease.yunxin.nertc.nertcvideocall.model.impl.NERtcCallbackProxyMgr;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DataFactory {
+
+  private static final DataFactory instance = new DataFactory();
+
+  private DataFactory() {}
+
+  public static DataFactory getInstance() {
+    return instance;
+  }
+
+  //静态参数成员
+  public final JoinChannelCallBack joinChannelCallBack =
+      new JoinChannelCallBack() {
+
+        @Override
+        public void onJoinChannel(V2NIMSignallingRoomInfo roomInfo) {
+          Hawk.getInstance().reportWithCurrentCaseId(0, "onJoinChannel", roomInfo);
+        }
+
+        @Override
+        public void onJoinFail(String msg, int code) {
+          Hawk.getInstance().reportWithCurrentCaseId(code, msg, null);
+        }
+      };
+
+  public final RequestCallback callback =
+      new RequestCallback() {
+
+        @Override
+        public void onSuccess(Object param) {
+          Hawk.getInstance().reportWithCurrentCaseId(0, "onSuccess", param);
+        }
+
+        @Override
+        public void onFailed(int code) {
+          Hawk.getInstance().reportWithCurrentCaseId(code, "onFailed", null);
+        }
+
+        @Override
+        public void onException(Throwable exception) {
+          Hawk.getInstance().reportWithCurrentCaseId(-1, exception.getMessage(), null);
+        }
+      };
+
+  public final Map<String, String> callbackMap = new HashMap<>();
+  public final NERTCCallingDelegate nertcCallingDelegate =
+      new NERTCCallingDelegate() {
+        @Override
+        public void onError(int errorCode, String errorMsg, boolean needFinish) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onError"), errorCode, errorMsg, needFinish);
+        }
+
+        @Override
+        public void onInvited(InvitedInfo invitedInfo) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onInvited"), 0, "success", invitedInfo);
+        }
+
+        @Override
+        public void onUserEnter(String userId) {
+          Hawk.getInstance().reportWithCaseId(callbackMap.get("onUserEnter"), 0, "success", userId);
+        }
+
+        @Override
+        public void onCallEnd(String userId) {
+          Hawk.getInstance().reportWithCaseId(callbackMap.get("onCallEnd"), 0, "success", userId);
+        }
+
+        @Override
+        public void onUserLeave(String userId) {
+          Hawk.getInstance().reportWithCaseId(callbackMap.get("onUserLeave"), 0, "success", userId);
+        }
+
+        @Override
+        public void onUserDisconnect(String userId) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onUserDisconnect"), 0, "success", userId);
+        }
+
+        @Override
+        public void onRejectByUserId(String userId) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onRejectByUserId"), 0, "success", userId);
+        }
+
+        @Override
+        public void onUserBusy(String userId) {
+          Hawk.getInstance().reportWithCaseId(callbackMap.get("onUserBusy"), 0, "success", userId);
+        }
+
+        @Override
+        public void onCancelByUserId(String userId) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onCancelByUserId"), 0, "success", userId);
+        }
+
+        @Override
+        public void onCameraAvailable(String userId, boolean isVideoAvailable) {
+          Hawk.getInstance()
+              .reportWithCaseId(
+                  callbackMap.get("onCameraAvailable"), 0, "success", isVideoAvailable);
+        }
+
+        @Override
+        public void onVideoMuted(String userId, boolean isMuted) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onVideoMuted"), 0, "success", isMuted);
+        }
+
+        @Override
+        public void onAudioMuted(String userId, boolean isMuted) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onAudioMuted"), 0, "success", isMuted);
+        }
+
+        @Override
+        public void onJoinChannel(String accId, long uid, String channelName, long rtcChannelId) {
+          //            Hawk.getInstance().reportInListener(0, "onJoinChannel", channelName, nertcCallingDelegate);
+          Hawk.getInstance().reportWithCaseId(callbackMap.get("onJoinChannel"), 0, "success", null);
+        }
+
+        @Override
+        public void onAudioAvailable(String userId, boolean isAudioAvailable) {
+          Hawk.getInstance()
+              .reportWithCaseId(
+                  callbackMap.get("onAudioAvailable"), 0, "success", isAudioAvailable);
+        }
+
+        @Override
+        public void onDisconnect(int res) {}
+
+        @Override
+        public void onUserNetworkQuality(Entry<String, Integer>[] stats) {}
+
+        @Override
+        public void onCallTypeChange(NECallTypeChangeInfo info) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onCallTypeChange"), 0, "success", info);
+        }
+
+        @Override
+        public void timeOut() {
+          Hawk.getInstance().reportWithCaseId(callbackMap.get("timeOut"), 0, "success", null);
+        }
+
+        @Override
+        public void onFirstVideoFrameDecoded(String userId, int width, int height) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onFirstVideoFrameDecoded"), 0, "success", null);
+        }
+
+        @Override
+        public void onLocalAction(int actionId, int resultCode) {}
+      };
+
+  public final NEResultObserver resultObserver =
+      result -> {
+        if (result instanceof CommonResult<?>) {
+          CommonResult<?> commonResult = (CommonResult<?>) result;
+          Hawk.getInstance()
+              .reportWithCurrentCaseId(commonResult.code, "onResult", commonResult.data);
+        } else {
+          Hawk.getInstance().reportWithCurrentCaseId(-1, "onResult", null);
+        }
+      };
+
+  public final NERecordProvider recordProvider =
+      record ->
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onRecordSend"), 0, "success", record);
+
+  public final NECallEngineDelegate callEngineDelegate =
+      new NECallEngineDelegate() {
+        @Override
+        public void onReceiveInvited(NEInviteInfo info) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onReceiveInvited"), 0, "success", info);
+        }
+
+        @Override
+        public void onCallConnected(NECallInfo info) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onCallConnected"), 0, "success", info);
+        }
+
+        @Override
+        public void onCallTypeChange(NECallTypeChangeInfo info) {
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onCallTypeChange"), 0, "success", info);
+        }
+
+        @Override
+        public void onCallEnd(NECallEndInfo info) {
+          Hawk.getInstance().reportWithCaseId(callbackMap.get("onCallEnd"), 0, "success", info);
+        }
+
+        @Override
+        public void onVideoAvailable(String userId, boolean available) {
+          Map<String, Object> map = new HashMap<>();
+          map.put("userId", userId);
+          map.put("available", available);
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onVideoAvailable"), 0, "success", map);
+        }
+
+        @Override
+        public void onVideoMuted(String userId, boolean mute) {
+          Map<String, Object> map = new HashMap<>();
+          map.put("userId", userId);
+          map.put("muted", mute);
+          Hawk.getInstance().reportWithCaseId(callbackMap.get("onVideoMuted"), 0, "success", map);
+        }
+
+        @Override
+        public void onAudioMuted(String userId, boolean mute) {
+          Map<String, Object> map = new HashMap<>();
+          map.put("userId", userId);
+          map.put("muted", mute);
+          Hawk.getInstance().reportWithCaseId(callbackMap.get("onAudioMuted"), 0, "success", map);
+        }
+      };
+
+  public final NERtcCallbackExTemp callbackExTemp =
+      new NERtcCallbackExTemp() {
+        @Override
+        public void onJoinChannel(int i, long l, long l1, long l2) {
+          super.onJoinChannel(i, l, l1, l2);
+          Map<String, Object> data = new HashMap<>();
+          data.put("result", i);
+          data.put("rtcChannelId", l);
+          data.put("time", l1);
+          data.put("uid", l2);
+
+          Hawk.getInstance()
+              .reportWithCaseId(callbackMap.get("onRtcJoinChannel"), 0, "success", data);
+        }
+      };
+
+  {
+    NERtcCallbackProxyMgr.getInstance()
+        .addCallback(
+            new NERtcCallbackExTemp() {
+              @Override
+              public void onFirstAudioFrameDecoded(long l) {
+                super.onFirstAudioFrameDecoded(l);
+                NERTCVideoCall.sharedInstance().getAccIdByRtcUid(l);
+              }
+            });
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/GetDeviceIdTest.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/GetDeviceIdTest.java
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+import android.util.Log;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.netease.yunxin.kit.integrationtest.utils.DeviceInfoUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
+ */
+@RunWith(AndroidJUnit4.class)
+public class GetDeviceIdTest {
+
+  @Test
+  public void test() {
+    String deviceId = (new DeviceInfoUtil()).getDeviceName();
+    Log.d("======> running on ", deviceId);
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/LoginUtils.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/LoginUtils.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+import android.os.Handler;
+import android.os.Looper;
+import com.netease.nimlib.sdk.auth.LoginInfo;
+import com.netease.yunxin.app.videocall.login.LoginManager;
+import com.netease.yunxin.nertc.ui.callback.NECallback;
+
+public final class LoginUtils {
+  private static final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+  public static void login(String accountId, String token, ResultNotify notify) {
+    mainHandler.post(() -> loginWithAccountToken(accountId, token, notify));
+  }
+
+  private static void loginWithAccountToken(String accountId, String token, ResultNotify notify) {
+
+    LoginManager.getInstance()
+        .login(
+            new LoginInfo(accountId, token),
+            new NECallback<Void>() {
+
+              @Override
+              public void onSuccess(Void result) {
+                notify.notifyResult(200);
+              }
+
+              @Override
+              public void onError(int code, String errorMsg) {
+                notify.notifyResult(code);
+              }
+            });
+  }
+
+  public static void logout(ResultNotify notify) {
+    mainHandler.post(() -> logoutAndIM(notify));
+  }
+
+  private static void logoutAndIM(ResultNotify notify) {
+    LoginManager.getInstance().logout();
+    notify.notifyResult(200);
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/ResultNotify.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/ResultNotify.java
@@ -1,0 +1,10 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest;
+
+public interface ResultNotify {
+
+  void notifyResult(int code);
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/android_api_test.sh
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/android_api_test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Copyright (c) 2022 NetEase, Inc. All rights reserved.
+# Use of this source code is governed by a MIT license that can be
+# found in the LICENSE file.
+
+set -x
+# 自定义修改
+selectPartNameList=[\"Case1\"]
+platform="android"
+appId="1005"
+
+## 执行方式 ===========
+# sh android_ui_test.sh "callkit" "1.4.0" "PBV7N16A12000656" "UJK0220410050250"
+# "android1": "231129212745115",
+#  "android2": "875914692556114"
+# sh android_ui_test.sh "callkit" "1.3.4" "D5F7N18516008620" "UJK0220410050250"
+
+###########################################
+arr=$*
+params=($arr)
+
+adb="$HOME/Library/Android/sdk/platform-tools/adb"
+host="59.111.31.178"
+#host="10.242.148.84:9090"
+caseId=""
+echo "$adb"
+#$adb devices
+startRunning() {
+    for i in $arr; do
+      if [ "$i" == "" ]; then
+        echo "当前参数为空 $i "
+      else
+        adb -s "${i}" shell am instrument -w -m   -e debug false -e class 'com.netease.yunxin.app.videocall.apitest.CallKitTestLauncher' com.netease.yunxin.app.videocall.test/androidx.test.runner.AndroidJUnitRunner  &    echo "start running $i "
+      fi
+    done
+}
+
+# CI接口使用
+hasNextPart() {
+  result=$(curl "http://${host}:9000/hasNextPart?deviceId=156487853555010" \
+    -H 'Content-Type: application/json; charset=utf-8')
+
+  value=$(parse_json "$result" "currentIndex")
+  echo "$value"
+}
+
+# 默认支持两台设备，如果需要运行，需要注册手机设备@赵冲
+#  "selectPartNameList": [],
+dispatchDevice() {
+result=$(curl -X "PUT" "http://${host}/caseGroup/dispatch" \
+     -H 'Content-Type: application/json; charset=utf-8' \
+     -d $'{
+  "platform":"'${platform}'",
+  "appId": "'${appId}'",
+  "version": "'${params[1]}'",
+  "deviceIdMap":  {
+    "android1": "'${params[2]}'",
+    "android2":  "'${params[3]}'"
+  },
+  "env": "'${params[0]}'"
+}')
+  # shellcheck disable=SC2034
+  taskId=$(parse_json "$result" "taskId")
+  echo "===>>>taskId"
+}
+sendFirst() {
+result=$(curl -X "POST" "http://${host}/push/start/$1/$2" \
+     -H 'Content-Type: application/json; charset=utf-8')
+   code=$(parse_json "$result" "code")
+   echo "====$code"
+}
+
+executeCase() {
+#  remoteIndex=$(hasNextPart)
+#    if [[ $remoteIndex == "-1" ]]; then
+#      sleep 3
+#      echo "当前没有需要执行的用例了"
+#      return
+#    fi
+    echo "***********exe nextPart start*********"
+    startRunning
+    echo "************exe nextPart end********"
+}
+
+parse_json(){
+echo "${1//\"/}" | sed "s/.*$2:\([^,}]*\).*/\1/"
+}
+
+executeCase
+sleep 6
+dispatchDevice
+sendFirst "$taskId"  "$caseId"
+echo "all is ending"
+

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/handlecase/HandleCallbackCase.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/handlecase/HandleCallbackCase.java
@@ -1,0 +1,97 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest.handlecase;
+
+import android.util.Log;
+import com.netease.yunxin.app.videocall.apitest.DataFactory;
+import com.netease.yunxin.kit.integrationtest.base.AbsHandleIntegratedEvent;
+import com.netease.yunxin.kit.integrationtest.model.TestItem;
+
+//占位过滤操作
+public class HandleCallbackCase extends AbsHandleIntegratedEvent<TestItem> {
+  @Override
+  public boolean handle(TestItem testItem) throws Exception {
+    super.handle(testItem);
+    Log.d("=======>", "start");
+    boolean res = false;
+    switch (methodName) {
+      case "onRecordSend":
+        DataFactory.getInstance().callbackMap.put("onRecordSend", testItem.getCaseId());
+        res = true;
+        break;
+      case "onVideoAvailable":
+        DataFactory.getInstance().callbackMap.put("onVideoAvailable", testItem.getCaseId());
+        res = true;
+        break;
+      case "onCallConnected":
+        DataFactory.getInstance().callbackMap.put("onCallConnected", testItem.getCaseId());
+        res = true;
+        break;
+      case "onReceiveInvited":
+        DataFactory.getInstance().callbackMap.put("onReceiveInvited", testItem.getCaseId());
+        res = true;
+        break;
+      case "onInvited":
+        DataFactory.getInstance().callbackMap.put("onInvited", testItem.getCaseId());
+        res = true;
+        break;
+      case "onAudioAvailable":
+        DataFactory.getInstance().callbackMap.put("onAudioAvailable", testItem.getCaseId());
+        res = true;
+        break;
+      case "onFirstVideoFrameDecoded":
+        DataFactory.getInstance().callbackMap.put("onFirstVideoFrameDecoded", testItem.getCaseId());
+        res = true;
+        break;
+      case "onCallTypeChange":
+        DataFactory.getInstance().callbackMap.put("onCallTypeChange", testItem.getCaseId());
+        res = true;
+        break;
+      case "onCancelByUserId":
+        DataFactory.getInstance().callbackMap.put("onCancelByUserId", testItem.getCaseId());
+        res = true;
+        break;
+      case "onUserEnter":
+        DataFactory.getInstance().callbackMap.put("onUserEnter", testItem.getCaseId());
+        res = true;
+        break;
+      case "onCallEnd":
+        DataFactory.getInstance().callbackMap.put("onCallEnd", testItem.getCaseId());
+        res = true;
+        break;
+      case "onRejectByUserId":
+        DataFactory.getInstance().callbackMap.put("onRejectByUserId", testItem.getCaseId());
+        res = true;
+        break;
+      case "onCameraAvailable":
+        DataFactory.getInstance().callbackMap.put("onCameraAvailable", testItem.getCaseId());
+        res = true;
+        break;
+      case "onVideoMuted":
+        DataFactory.getInstance().callbackMap.put("onVideoMuted", testItem.getCaseId());
+        res = true;
+        break;
+      case "onAudioMuted":
+        DataFactory.getInstance().callbackMap.put("onAudioMuted", testItem.getCaseId());
+        res = true;
+        break;
+      case "onJoinChannel":
+        DataFactory.getInstance().callbackMap.put("onJoinChannel", testItem.getCaseId());
+        res = true;
+        break;
+      case "onUserBusy":
+        DataFactory.getInstance().callbackMap.put("onUserBusy", testItem.getCaseId());
+        res = true;
+        break;
+      case "timeOut":
+        DataFactory.getInstance().callbackMap.put("timeOut", testItem.getCaseId());
+        res = true;
+        break;
+      default:
+        break;
+    }
+    return res;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/handlecase/LoginCase.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/handlecase/LoginCase.java
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest.handlecase;
+
+import android.text.TextUtils;
+import android.util.Log;
+import com.netease.yunxin.app.videocall.apitest.LoginUtils;
+import com.netease.yunxin.app.videocall.login.LoginManager;
+import com.netease.yunxin.kit.integrationtest.Hawk;
+import com.netease.yunxin.kit.integrationtest.base.AbsHandleIntegratedEvent;
+import com.netease.yunxin.kit.integrationtest.model.TestItem;
+
+public class LoginCase extends AbsHandleIntegratedEvent<TestItem> {
+  @Override
+  public boolean handle(TestItem testItem) throws Exception {
+    super.handle(testItem);
+    Log.d("LoginCase =======>", "start：" + methodName);
+    boolean res = false;
+    if (TextUtils.equals(methodName, "login")) {
+      String accountId =
+          testItem.getParams().get(0).get("info").getAsJsonObject().get("accountId").getAsString();
+      String token =
+          testItem.getParams().get(0).get("info").getAsJsonObject().get("token").getAsString();
+      LoginUtils.login(
+          accountId,
+          token,
+          code ->
+              Hawk.getInstance()
+                  .reportWithCurrentCaseId(
+                      code, "loginResult", LoginManager.getInstance().getUserModel()));
+      res = true;
+    } else if (TextUtils.equals(methodName, "logout")) {
+      res = true;
+      LoginUtils.logout(
+          code -> Hawk.getInstance().reportWithCurrentCaseId(code, "logoutResult", code));
+    }
+    return res;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/handlecase/NewInterfaceV2Case.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/handlecase/NewInterfaceV2Case.java
@@ -1,0 +1,176 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest.handlecase;
+
+import android.text.TextUtils;
+import android.util.Log;
+import androidx.test.core.app.ApplicationProvider;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+import com.netease.yunxin.kit.call.p2p.NECallEngine;
+import com.netease.yunxin.kit.call.p2p.model.NECallConfig;
+import com.netease.yunxin.kit.call.p2p.model.NECallPushConfig;
+import com.netease.yunxin.kit.call.p2p.model.NESetupConfig;
+import com.netease.yunxin.kit.call.p2p.param.NECallParam;
+import com.netease.yunxin.kit.call.p2p.param.NEHangupParam;
+import com.netease.yunxin.kit.call.p2p.param.NESwitchParam;
+import com.netease.yunxin.kit.integrationtest.Hawk;
+import com.netease.yunxin.kit.integrationtest.base.AbsHandleIntegratedEvent;
+import com.netease.yunxin.kit.integrationtest.model.TestItem;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public class NewInterfaceV2Case extends AbsHandleIntegratedEvent<TestItem> {
+
+  @Override
+  public boolean handle(TestItem testItem) throws Exception {
+    super.handle(testItem);
+    Log.d(
+        "NewInterfaceV2Case =======>",
+        "start:" + methodName + ", className:" + testItem.getClassName());
+    boolean res = false;
+    if (!TextUtils.equals(testItem.getClassName(), "NECallEngine")) {
+      return res;
+    }
+
+    JsonObject paramObj = new JsonObject();
+    if (testItem.getParams() != null
+        && !testItem.getParams().isEmpty()
+        && testItem.getParams().get(0).get("param") != null) {
+      Object tempObj = testItem.getParams().get(0).get("param");
+      if (tempObj instanceof JsonObject) {
+        paramObj = testItem.getParams().get(0).get("param").getAsJsonObject();
+      }
+    }
+    if (TextUtils.equals(methodName, "setup")) {
+      if (paramObj == null) {
+        Hawk.getInstance().reportWithCurrentCaseId(-1, "param is error", null);
+        return true;
+      }
+      NESetupConfig.Builder builder =
+          new NESetupConfig.Builder(paramObj.get("appKey").getAsString());
+      if (paramObj.get("enableJoinRtcWhenCall") != null) {
+        builder.enableJoinRtcWhenCall(paramObj.get("enableJoinRtcWhenCall").getAsBoolean());
+      }
+      if (paramObj.get("currentUserRtcUid") != null) {
+        builder.currentUserRtcUid(paramObj.get("currentUserRtcUid").getAsLong());
+      }
+      if (paramObj.get("initRtcMode") != null) {
+        builder.initRtcMode(paramObj.get("initRtcMode").getAsInt());
+      }
+      if (paramObj.get("enableAutoJoinSignalChannel") != null) {
+        builder.enableAutoJoinSignalChannel(
+            paramObj.get("enableAutoJoinSignalChannel").getAsBoolean());
+      }
+      NESetupConfig setupConfig = builder.build();
+      Log.d("NewInterfaceV2Case =======>", "start:" + methodName + ", NESetupConfig" + setupConfig);
+      NECallEngine.sharedInstance().setup(ApplicationProvider.getApplicationContext(), setupConfig);
+      Hawk.getInstance().reportWithCurrentCaseId(0, "setup", null);
+      res = true;
+    } else if (TextUtils.equals(methodName, "call")) {
+      NECallParam.Builder builder = new NECallParam.Builder(paramObj.get("accId").getAsString());
+      if (paramObj.get("callType") != null) {
+        builder.callType(paramObj.get("callType").getAsInt());
+      }
+      if (paramObj.get("extraInfo") != null) {
+        builder.extraInfo(paramObj.get("extraInfo").getAsString());
+      }
+      if (paramObj.get("rtcChannelName") != null) {
+        builder.rtcChannelName(paramObj.get("rtcChannelName").getAsString());
+      }
+      if (paramObj.get("globalExtraCopy") != null) {
+        builder.globalExtraCopy(paramObj.get("globalExtraCopy").getAsString());
+      }
+      if (paramObj.get("pushConfig") != null) {
+        JsonObject pushConfigObj = paramObj.get("pushConfig").getAsJsonObject();
+        boolean needPush = true;
+        if (pushConfigObj.get("needPush") != null) {
+          needPush = pushConfigObj.get("needPush").getAsBoolean();
+        }
+        String title = null;
+        if (pushConfigObj.get("pushTitle") != null) {
+          title = pushConfigObj.get("pushTitle").getAsString();
+        }
+        String content = null;
+        if (pushConfigObj.get("pushContent") != null) {
+          content = pushConfigObj.get("pushContent").getAsString();
+        }
+        Map<String, Object> payload = null;
+        if (pushConfigObj.get("pushPayload") != null) {
+          JsonObject payloadObj = pushConfigObj.get("pushPayload").getAsJsonObject();
+          Gson gson = new Gson();
+          Type type = new TypeToken<Map<String, Object>>() {}.getType();
+          payload = gson.fromJson(payloadObj, type);
+        }
+        NECallPushConfig config = new NECallPushConfig(needPush, title, content, payload);
+        builder.pushConfig(config);
+      }
+      NECallEngine.sharedInstance()
+          .call(
+              builder.build(),
+              result ->
+                  Hawk.getInstance().reportWithCurrentCaseId(result.code, "call", result.data));
+      res = true;
+    } else if (TextUtils.equals(methodName, "accept")) {
+      NECallEngine.sharedInstance()
+          .accept(
+              result ->
+                  Hawk.getInstance().reportWithCurrentCaseId(result.code, "accept", result.data));
+      res = true;
+    } else if (TextUtils.equals(methodName, "hangup")) {
+      String extraInfo = null;
+      if (paramObj.get("extraString") != null) {
+        extraInfo = paramObj.get("extraString").getAsString();
+      }
+      String channelId = null;
+      if (paramObj.get("channelId") != null) {
+        channelId = paramObj.get("channelId").getAsString();
+      }
+      NECallEngine.sharedInstance()
+          .hangup(
+              new NEHangupParam(channelId, extraInfo),
+              result ->
+                  Hawk.getInstance().reportWithCurrentCaseId(result.code, "hangup", result.data));
+      res = true;
+    } else if (TextUtils.equals(methodName, "switchCallType")) {
+      int callType = paramObj.get("callType").getAsInt();
+      int state = paramObj.get("state").getAsInt();
+      NECallEngine.sharedInstance()
+          .switchCallType(
+              new NESwitchParam(callType, state),
+              result ->
+                  Hawk.getInstance()
+                      .reportWithCurrentCaseId(result.code, "switchCallType", result.data));
+      res = true;
+    } else if (TextUtils.equals(methodName, "setCallConfig")) {
+      NECallConfig callConfig = NECallEngine.sharedInstance().getCallConfig();
+      boolean enableOffline;
+      if (paramObj.get("enableOffline") != null) {
+        enableOffline = paramObj.get("enableOffline").getAsBoolean();
+      } else {
+        enableOffline = callConfig.enableOffline;
+      }
+      boolean enableSwitchVideoConfirm;
+      if (paramObj.get("enableSwitchVideoConfirm") != null) {
+        enableSwitchVideoConfirm = paramObj.get("enableSwitchVideoConfirm").getAsBoolean();
+      } else {
+        enableSwitchVideoConfirm = callConfig.enableSwitchVideoConfirm;
+      }
+      boolean enableSwitchAudioConfirm;
+      if (paramObj.get("enableSwitchAudioConfirm") != null) {
+        enableSwitchAudioConfirm = paramObj.get("enableSwitchAudioConfirm").getAsBoolean();
+      } else {
+        enableSwitchAudioConfirm = callConfig.enableSwitchAudioConfirm;
+      }
+      NECallEngine.sharedInstance()
+          .setCallConfig(
+              new NECallConfig(enableOffline, enableSwitchVideoConfirm, enableSwitchAudioConfirm));
+      Hawk.getInstance().reportWithCurrentCaseId(0, "setCallConfig", null);
+      res = true;
+    }
+    return res;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/handlecase/RtcHelperCase.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/apitest/handlecase/RtcHelperCase.java
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.apitest.handlecase;
+
+import android.text.TextUtils;
+import com.netease.yunxin.app.videocall.apitest.DataFactory;
+import com.netease.yunxin.kit.integrationtest.Hawk;
+import com.netease.yunxin.kit.integrationtest.base.AbsHandleIntegratedEvent;
+import com.netease.yunxin.kit.integrationtest.model.TestItem;
+import com.netease.yunxin.nertc.nertcvideocall.model.impl.NERtcCallbackProxyMgr;
+
+public class RtcHelperCase extends AbsHandleIntegratedEvent<TestItem> {
+  @Override
+  public boolean handle(TestItem testItem) throws Exception {
+    super.handle(testItem);
+    boolean res = false;
+    if (!TextUtils.equals(testItem.getClassName(), "RTC")) {
+      return res;
+    }
+    if (TextUtils.equals(methodName, "onRtcJoinChannel")) {
+      DataFactory.getInstance().callbackMap.put("onRtcJoinChannel", testItem.getCaseId());
+      res = true;
+    } else if (TextUtils.equals(methodName, "add")) {
+      NERtcCallbackProxyMgr.getInstance().addCallback(DataFactory.getInstance().callbackExTemp);
+      Hawk.getInstance().reportWithCurrentCaseId(0, "success", "");
+      res = true;
+    } else if (TextUtils.equals(methodName, "remove")) {
+      NERtcCallbackProxyMgr.getInstance().removeCallback(DataFactory.getInstance().callbackExTemp);
+      Hawk.getInstance().reportWithCurrentCaseId(0, "success", "");
+      res = true;
+    }
+    return res;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/BaseTestUtils.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/BaseTestUtils.java
@@ -1,0 +1,169 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.base;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withParent;
+import static androidx.test.espresso.matcher.ViewMatchers.withParentIndex;
+import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.ImageView;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.IdRes;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.contrib.RecyclerViewActions;
+import androidx.test.espresso.contrib.RecyclerViewActions.PositionableRecyclerViewAction;
+import androidx.test.espresso.matcher.BoundedMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+/** 基础测试方法封装 */
+@ClassRegister
+public final class BaseTestUtils {
+
+  public static ViewInteraction viewAction(@IdRes int id, final ViewAction... viewActions) {
+    return onView(withId(id)).perform(viewActions);
+  }
+
+  public static ViewInteraction viewAction(
+      Matcher<View> viewMatcher, final ViewAction... viewActions) {
+    return onView(viewMatcher).perform(viewActions);
+  }
+
+  public static ViewInteraction inputText(@IdRes int id, String content) {
+    return viewAction(id, typeText(content));
+  }
+
+  public static ViewInteraction inputText(Matcher<View> viewMatcher, String content) {
+    return viewAction(viewMatcher, typeText(content));
+  }
+
+  public static ViewInteraction checkText(@IdRes int id, String content) {
+    return findViewInteraction(id).check(matches(withText(content)));
+  }
+
+  public static ViewInteraction checkText(Matcher<View> viewMatcher, String content) {
+    return onView(viewMatcher).check(matches(withText(content)));
+  }
+
+  public static ViewInteraction containsText(@IdRes int id, String content) {
+    return findViewInteraction(id).check(matches(withSubstring(content)));
+  }
+
+  public static ViewInteraction containsText(Matcher<View> viewMatcher, String content) {
+    return onView(viewMatcher).check(matches(withSubstring(content)));
+  }
+
+  public static ViewInteraction checkLocalDrawable(@IdRes int id, @DrawableRes int drawableId) {
+    return findViewInteraction(id).check(matches(isAimLocalDrawable(drawableId)));
+  }
+
+  public static ViewInteraction checkLocalDrawable(
+      Matcher<View> viewMatcher, @DrawableRes int drawableId) {
+    return onView(viewMatcher).check(matches(isAimLocalDrawable(drawableId)));
+  }
+
+  public static ViewInteraction viewClick(@IdRes int id) {
+    return viewAction(id, click());
+  }
+
+  public static ViewInteraction viewClick(Matcher<View> viewMatcher) {
+    return viewAction(viewMatcher, click());
+  }
+
+  public static Matcher<View> findViewMatcherInGroup(
+      @IdRes int parentId, String childTypeClassName, int index) {
+    return allOf(
+        withParent(withId(parentId)),
+        withClassName(is(childTypeClassName)),
+        withParentIndex(index));
+  }
+
+  public static ViewInteraction findViewInteraction(@IdRes int id) {
+    return onView(withId(id));
+  }
+
+  public static ViewInteraction findViewInteractionInGroup(
+      @IdRes int parentId, String childTypeClassName, int index) {
+    return onView(findViewMatcherInGroup(parentId, childTypeClassName, index));
+  }
+
+  public static <T extends RecyclerView.ViewHolder> ViewInteraction actionOnRecyclerItemWithHolder(
+      @IdRes int recyclerViewId, Matcher<T> holderMatcher, final ViewAction action) {
+    return viewAction(recyclerViewId, actionOnHolderItem(holderMatcher, action));
+  }
+
+  public static <T extends RecyclerView.ViewHolder> ViewInteraction clickOnRecyclerItemWithHolder(
+      @IdRes int recyclerViewId, Matcher<T> holderMatcher) {
+    return viewAction(recyclerViewId, actionOnHolderItem(holderMatcher, click()));
+  }
+
+  public static ViewInteraction actionOnRecyclerItemWithPosition(
+      @IdRes int recyclerViewId, int position, final ViewAction action) {
+    return viewAction(recyclerViewId, actionOnItemAtPosition(position, action));
+  }
+
+  public static ViewInteraction clickOnRecyclerItemWithPosition(
+      @IdRes int recyclerViewId, int position) {
+    return viewAction(recyclerViewId, actionOnItemAtPosition(position, click()));
+  }
+
+  public static <T extends RecyclerView.ViewHolder>
+      PositionableRecyclerViewAction actionOnHolderItem(
+          Matcher<T> holderMatcher, ViewAction action) {
+    return RecyclerViewActions.actionOnHolderItem(holderMatcher, action);
+  }
+
+  public static ViewAction actionOnItemAtPosition(int position, ViewAction action) {
+    return RecyclerViewActions.actionOnItemAtPosition(position, action);
+  }
+
+  public static void waitForTime(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void pressBack() {
+    Espresso.pressBack();
+  }
+
+  public static BoundedMatcher<View, ImageView> isAimLocalDrawable(@DrawableRes int id) {
+    return new BoundedMatcher<View, ImageView>(ImageView.class) {
+      @Override
+      protected boolean matchesSafely(ImageView item) {
+        if (item == null) {
+          return false;
+        }
+        Context context = item.getContext();
+        if (context == null) {
+          return false;
+        }
+        return item.getDrawable().getCurrent().getConstantState()
+            == context.getResources().getDrawable(id).getConstantState();
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("is same drawable");
+      }
+    };
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/ClassRegister.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/ClassRegister.java
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.base;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ClassRegister {
+  String value() default "";
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/MethodExclude.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/MethodExclude.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.base;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Inherited
+public @interface MethodExclude {}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/MethodInfo.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/MethodInfo.java
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.base;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.List;
+
+public class MethodInfo {
+  public final String className;
+  public final Method method;
+
+  public MethodInfo(String className, Method method) {
+    this.className = className;
+    this.method = method;
+  }
+
+  public Object execute(Object obj, List<Object> param) {
+    Object result = null;
+    try {
+      result =
+          method.invoke(Modifier.isStatic(method.getModifiers()) ? null : obj, param.toArray());
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      e.printStackTrace();
+    }
+    return result;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/MethodOtherName.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/MethodOtherName.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.base;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@interface MethodOtherName {
+  String value();
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/TestHelper.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/base/TestHelper.java
@@ -1,0 +1,102 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.base;
+
+import android.text.TextUtils;
+import android.util.Log;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.netease.yunxin.kit.integrationtest.model.TestItem;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class TestHelper {
+  private static final Map<String, MethodInfo> methodMap = new HashMap<>();
+
+  public static void registerClass(Class<?>... classes) {
+    for (Class<?> clazz : classes) {
+      ClassRegister item = clazz.getDeclaredAnnotation(ClassRegister.class);
+      if (item == null) {
+        System.out.println(
+            "Class# "
+                + clazz.getCanonicalName()
+                + " can't be registered without ClassRegister Annotation.");
+        continue;
+      }
+      String className = item.value();
+      if (TextUtils.isEmpty(className)) {
+        className = clazz.getCanonicalName();
+      }
+
+      Method[] methods = clazz.getDeclaredMethods();
+      for (Method method : methods) {
+        if (method.isAnnotationPresent(MethodExclude.class)) {
+          continue;
+        }
+
+        MethodOtherName otherName = method.getDeclaredAnnotation(MethodOtherName.class);
+        String name;
+        if (otherName != null) {
+          name = otherName.value();
+        } else {
+          name = method.getName();
+        }
+        if (methodMap.containsKey(name)) {
+          System.out.println(
+              "Method# " + name + " had been registered. MethodInfo is " + methodMap.get(name));
+          continue;
+        }
+
+        methodMap.put(name, new MethodInfo(className, method));
+      }
+    }
+  }
+
+  public static boolean handleMethod(Object obj, TestItem item) {
+    if (item == null) {
+      return false;
+    }
+    Log.e("!!!!!!!", item.getMethodName() + " start");
+    boolean result = false;
+    if (methodMap.containsKey(item.getMethodName())) {
+      MethodInfo methodInfo = methodMap.get(item.getMethodName());
+      if (methodInfo != null) {
+        methodInfo.execute(obj, parseParams(methodInfo.method, item.getParams()));
+        result = true;
+      }
+    }
+    Log.e("!!!!!!!", item.getMethodName() + " end");
+    return result;
+  }
+
+  private static List<Object> parseParams(Method method, List<JsonObject> params) {
+    Log.e("!!!!!!!", "parseParams start");
+    if (params == null || params.isEmpty()) {
+      return new ArrayList<>();
+    }
+    List<Object> paramObjList = new ArrayList<>(params.size());
+
+    try {
+      Type[] genericParameterTypes = method.getGenericParameterTypes();
+      for (int i = 0; i < params.size(); i++) {
+        JsonObject object = params.get(i);
+        Object item = new Gson().fromJson(object.get("").getAsString(), genericParameterTypes[i]);
+        paramObjList.add(item);
+      }
+    } catch (Exception exception) {
+      exception.printStackTrace();
+    }
+    Log.e("!!!!!!!", "parseParams end");
+    return paramObjList;
+  }
+
+  public static void releaseAll() {
+    methodMap.clear();
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/callkit/CallKitTestConstants.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/callkit/CallKitTestConstants.java
@@ -1,0 +1,103 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.callkit;
+
+import com.netease.yunxin.app.videocall.R;
+
+/** 呼叫组件中使用到的 id */
+public final class CallKitTestConstants {
+  /** view id 列表 */
+  public interface ViewIds {
+    int MAIN_P2P_CALL_ENTER = R.id.rly_video_call;
+
+    int MAIN_USER_AVATAR = R.id.iv_account;
+
+    int LOGIN_PHONE_INPUT = R.id.edt_account_id;
+
+    /** 登录密码模块有更新，需要重新适配 */
+    int LOGIN_SEND = R.id.edt_account_id;
+
+    int LOGIN_VERIFY_CODE_INPUT_PARENT = R.id.vcv_sms;
+
+    int LOGIN_NEXT = R.id.btn_next;
+
+    int SEARCH_PHONE_INPUT = R.id.edt_account_id;
+
+    int SEARCH_SEARCH = R.id.edt_account_id;
+
+    int SEARCH_RESULT_GROUP = R.id.edt_account_id;
+
+    int SEARCH_RECENT_GROUP = R.id.rv_recent_user;
+
+    int SEARCH_RECORD_GROUP = R.id.rv_call_order;
+
+    int CALL_CANCEL = R.id.ivCancel;
+
+    int CALL_ACCEPT = R.id.ivAccept;
+
+    int CALL_REJECT = R.id.ivReject;
+
+    int CALL_HANGUP = R.id.ivHangUp;
+
+    int CALL_AUDIO_SWITCH = R.id.ivMuteAudio;
+
+    int CALL_SPEAKER_SWITCH = R.id.ivMuteSpeaker;
+
+    int CALL_SWITCH_CALL_TYPE = R.id.ivCallChannelTypeChange;
+
+    int CALL_VIDEO_SWITCH = R.id.ivMuteVideo;
+
+    int CALL_CAMERA_FLIP = R.id.ivSwitchCamera;
+
+    int CALLER_SWITCH_CALL_TYPE = R.id.ivCallSwitchType;
+
+    int CALLER_AUDIO_SWITCH = R.id.ivCallMuteAudio;
+
+    int CALLER_SPEAKER_SWITCH = R.id.ivCallSpeaker;
+
+    int CALLEE_SWITCH_CALL_TYPE = R.id.ivSwitchType;
+  }
+
+  /** 文本内容 */
+  public interface TextContent {}
+
+  //--------------------- text ----------------------
+
+  /** 图片资源 id 列表 */
+  public interface DrawableRes {
+
+    int CALLER_SWITCH_CALL_TYPE_VIDEO = R.drawable.icon_call_tip_video_to_audio;
+
+    int CALLER_SWITCH_CALL_TYPE_AUDIO = R.drawable.icon_call_tip_audio_to_video;
+
+    int CALLER_MICRO_PHONE_ENABLE = R.drawable.icon_call_audio_on;
+
+    int CALLER_MICRO_PHONE_DISABLE = R.drawable.icon_call_audio_off;
+
+    int CALLER_SPEAKER_SWITCH_ENABLE = R.drawable.icon_call_audio_speaker_on;
+
+    int CALLER_SPEAKER_SWITCH_DISABLE = R.drawable.icon_call_audio_speaker_off;
+
+    int CALL_SWITCH_CALL_TYPE_VIDEO = R.drawable.video_to_audio;
+
+    int CALL_SWITCH_CALL_TYPE_AUDIO = R.drawable.audio_to_video;
+
+    int CALL_AUDIO_SWITCH_ENABLE = R.drawable.voice_on;
+
+    int CALL_AUDIO_SWITCH_DISABLE = R.drawable.voice_off;
+
+    int CALL_SPEAKER_SWITCH_ENABLE = R.drawable.speaker_on;
+
+    int CALL_SPEAKER_SWITCH_DISABLE = R.drawable.speaker_off;
+
+    int CALL_VIDEO_SWITCH_ENABLE = R.drawable.cam_on;
+
+    int CALL_VIDEO_SWITCH_DISABLE = R.drawable.cam_off;
+
+    int CALLEE_SWITCH_CALL_TYPE_VIDEO = R.drawable.icon_call_tip_video_to_audio;
+
+    int CALLEE_SWITCH_CALL_TYPE_AUDIO = R.drawable.icon_call_tip_audio_to_video;
+  }
+}

--- a/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/callkit/CallKitTestUtils.java
+++ b/Android/app/src/androidTest/java/com/netease/yunxin/app/videocall/callkit/CallKitTestUtils.java
@@ -1,0 +1,247 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.app.videocall.callkit;
+
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.netease.yunxin.app.videocall.base.BaseTestUtils.checkLocalDrawable;
+import static com.netease.yunxin.app.videocall.base.BaseTestUtils.clickOnRecyclerItemWithHolder;
+import static com.netease.yunxin.app.videocall.base.BaseTestUtils.clickOnRecyclerItemWithPosition;
+import static com.netease.yunxin.app.videocall.base.BaseTestUtils.findViewMatcherInGroup;
+import static com.netease.yunxin.app.videocall.base.BaseTestUtils.inputText;
+import static com.netease.yunxin.app.videocall.base.BaseTestUtils.viewClick;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALLEE_SWITCH_CALL_TYPE_AUDIO;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALLEE_SWITCH_CALL_TYPE_VIDEO;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALLER_MICRO_PHONE_DISABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALLER_MICRO_PHONE_ENABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALLER_SPEAKER_SWITCH_DISABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALLER_SPEAKER_SWITCH_ENABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALLER_SWITCH_CALL_TYPE_AUDIO;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALLER_SWITCH_CALL_TYPE_VIDEO;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALL_AUDIO_SWITCH_DISABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALL_AUDIO_SWITCH_ENABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALL_SPEAKER_SWITCH_DISABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALL_SPEAKER_SWITCH_ENABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALL_SWITCH_CALL_TYPE_AUDIO;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALL_SWITCH_CALL_TYPE_VIDEO;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALL_VIDEO_SWITCH_DISABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.DrawableRes.CALL_VIDEO_SWITCH_ENABLE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALLEE_SWITCH_CALL_TYPE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALLER_AUDIO_SWITCH;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALLER_SPEAKER_SWITCH;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALLER_SWITCH_CALL_TYPE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALL_ACCEPT;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALL_AUDIO_SWITCH;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALL_CAMERA_FLIP;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALL_CANCEL;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALL_HANGUP;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALL_REJECT;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALL_SPEAKER_SWITCH;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALL_SWITCH_CALL_TYPE;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.CALL_VIDEO_SWITCH;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.LOGIN_NEXT;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.LOGIN_PHONE_INPUT;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.LOGIN_SEND;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.LOGIN_VERIFY_CODE_INPUT_PARENT;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.MAIN_P2P_CALL_ENTER;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.MAIN_USER_AVATAR;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.SEARCH_PHONE_INPUT;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.SEARCH_RECENT_GROUP;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.SEARCH_RECORD_GROUP;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.SEARCH_RESULT_GROUP;
+import static com.netease.yunxin.app.videocall.callkit.CallKitTestConstants.ViewIds.SEARCH_SEARCH;
+
+import android.text.TextUtils;
+import android.widget.EditText;
+import androidx.test.espresso.ViewInteraction;
+import com.netease.nimlib.sdk.avsignalling.constant.ChannelType;
+import com.netease.yunxin.app.videocall.base.ClassRegister;
+import com.netease.yunxin.app.videocall.call.adapter.RecentUserAdapter;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/** 呼叫组件测试工具封装 */
+@ClassRegister
+public final class CallKitTestUtils {
+
+  //--- main
+  public static ViewInteraction clickP2PItem() {
+    return viewClick(MAIN_P2P_CALL_ENTER);
+  }
+
+  public static ViewInteraction clickUserAvatar() {
+    return viewClick(MAIN_USER_AVATAR);
+  }
+
+  public static ViewInteraction clickLogoutOption(boolean logout) {
+    return viewClick(withText(logout ? "是" : "否"));
+  }
+
+  //--- login
+  public static ViewInteraction inputLoginPhone(String phoneNum) {
+    return inputText(LOGIN_PHONE_INPUT, phoneNum);
+  }
+
+  public static ViewInteraction clickSendBtn() {
+    return viewClick(LOGIN_SEND);
+  }
+
+  public static void inputVerifyCode(String verifyCode) {
+    for (int i = 0; i < 4; i++) {
+      inputText(
+          findViewMatcherInGroup(LOGIN_VERIFY_CODE_INPUT_PARENT, EditText.class.getName(), i),
+          String.valueOf(verifyCode.charAt(i)));
+    }
+  }
+
+  public static ViewInteraction clickNextBtn() {
+    return viewClick(LOGIN_NEXT);
+  }
+
+  //-------------- search page
+  public static ViewInteraction inputSearchPhone(String phoneNum) {
+    return inputText(SEARCH_PHONE_INPUT, phoneNum);
+  }
+
+  public static ViewInteraction clickSearchBtn() {
+    return viewClick(withId(SEARCH_SEARCH));
+  }
+
+  public static ViewInteraction clickSearchResult(String verifyPhoneNum) {
+    return clickOnRecyclerItemWithHolder(
+        SEARCH_RESULT_GROUP, hasTextInHolderWithRecent(verifyPhoneNum));
+  }
+
+  public static ViewInteraction clickRecordByIndex(int index) {
+    return clickOnRecyclerItemWithPosition(SEARCH_RECORD_GROUP, index);
+  }
+
+  public static ViewInteraction clickRecentByIndex(int index) {
+    return clickOnRecyclerItemWithPosition(SEARCH_RECENT_GROUP, index);
+  }
+
+  //--------------- on the call page
+  public static ViewInteraction clickCancelBtn() {
+    return viewClick(CALL_CANCEL);
+  }
+
+  public static ViewInteraction clickRejectBtn() {
+    return viewClick(CALL_REJECT);
+  }
+
+  public static ViewInteraction clickAcceptBtn() {
+    return viewClick(CALL_ACCEPT);
+  }
+
+  public static ViewInteraction clickHangupBtn() {
+    return viewClick(CALL_HANGUP);
+  }
+
+  public static ViewInteraction clickMicroPhoneBtn() {
+    return viewClick(CALL_AUDIO_SWITCH);
+  }
+
+  public static ViewInteraction checkMicroPhoneState(boolean enable) {
+    return checkLocalDrawable(
+        CALL_AUDIO_SWITCH, enable ? CALL_AUDIO_SWITCH_ENABLE : CALL_AUDIO_SWITCH_DISABLE);
+  }
+
+  public static ViewInteraction clickSpeakerBtn() {
+    return viewClick(CALL_SPEAKER_SWITCH);
+  }
+
+  public static ViewInteraction checkSpeakerState(boolean enable) {
+    return checkLocalDrawable(
+        CALL_SPEAKER_SWITCH, enable ? CALL_SPEAKER_SWITCH_ENABLE : CALL_SPEAKER_SWITCH_DISABLE);
+  }
+
+  public static ViewInteraction clickSwitchTypeBtn() {
+    return viewClick(CALL_SWITCH_CALL_TYPE);
+  }
+
+  public static ViewInteraction checkSwitchType(int callType) {
+    return checkLocalDrawable(
+        CALL_SWITCH_CALL_TYPE,
+        callType == ChannelType.AUDIO.getValue()
+            ? CALL_SWITCH_CALL_TYPE_AUDIO
+            : CALL_SWITCH_CALL_TYPE_VIDEO);
+  }
+
+  public static ViewInteraction clickMuteVideoBtn() {
+    return viewClick(CALL_VIDEO_SWITCH);
+  }
+
+  public static ViewInteraction checkMuteVideoState(boolean enable) {
+    return checkLocalDrawable(
+        CALL_VIDEO_SWITCH, enable ? CALL_VIDEO_SWITCH_ENABLE : CALL_VIDEO_SWITCH_DISABLE);
+  }
+
+  public static ViewInteraction clickCallerSwitchTypeBtnWhenCall() {
+    return viewClick(CALLER_SWITCH_CALL_TYPE);
+  }
+
+  public static ViewInteraction checkCallerSwitchTypeWhenCallState(int callType) {
+    return checkLocalDrawable(
+        CALLER_SWITCH_CALL_TYPE,
+        callType == ChannelType.AUDIO.getValue()
+            ? CALLER_SWITCH_CALL_TYPE_AUDIO
+            : CALLER_SWITCH_CALL_TYPE_VIDEO);
+  }
+
+  public static ViewInteraction clickCallerMicroPhoneBtnWhenCall() {
+    return viewClick(CALLER_AUDIO_SWITCH);
+  }
+
+  public static ViewInteraction checkCallerMicroPhoneWhenCallState(boolean enable) {
+    return checkLocalDrawable(
+        CALLER_AUDIO_SWITCH, enable ? CALLER_MICRO_PHONE_ENABLE : CALLER_MICRO_PHONE_DISABLE);
+  }
+
+  public static ViewInteraction clickCallerSpeakerWhenCall() {
+    return viewClick(CALLER_SPEAKER_SWITCH);
+  }
+
+  public static ViewInteraction checkCallerSpeakerWhenCallState(boolean enable) {
+    return checkLocalDrawable(
+        CALLER_SPEAKER_SWITCH,
+        enable ? CALLER_SPEAKER_SWITCH_ENABLE : CALLER_SPEAKER_SWITCH_DISABLE);
+  }
+
+  public static ViewInteraction clickCalleeSwitchTypeBtnWhenCall() {
+    return viewClick(CALLEE_SWITCH_CALL_TYPE);
+  }
+
+  public static ViewInteraction checkCalleeSwitchTypeWhenCallState(int callType) {
+    return checkLocalDrawable(
+        CALLEE_SWITCH_CALL_TYPE,
+        callType == ChannelType.AUDIO.getValue()
+            ? CALLEE_SWITCH_CALL_TYPE_AUDIO
+            : CALLEE_SWITCH_CALL_TYPE_VIDEO);
+  }
+
+  public static ViewInteraction clickCameraFlip() {
+    return viewClick(CALL_CAMERA_FLIP);
+  }
+
+  public static ViewInteraction clickEndCallOption(boolean end) {
+    return viewClick(withText(end ? "是" : "否"));
+  }
+
+  //------------------ self matcher method
+  public static Matcher<RecentUserAdapter.ViewHolder> hasTextInHolderWithRecent(String text) {
+    return new TypeSafeMatcher<RecentUserAdapter.ViewHolder>() {
+      @Override
+      protected boolean matchesSafely(RecentUserAdapter.ViewHolder customHolder) {
+        return TextUtils.equals(customHolder.tvNickname.getText(), text);
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("equals with text");
+      }
+    };
+  }
+}

--- a/Android/call-ui/build.gradle
+++ b/Android/call-ui/build.gradle
@@ -44,5 +44,6 @@ dependencies {
     implementation libs.glide
     implementation libs.glide.transformations
     api libs.yunxin.common.ui
-    api 'com.netease.yunxin.kit.call:call:3.8.0'
+    implementation 'com.netease.yunxin:nertc-aidenoise:5.9.10'
+    api 'com.netease.yunxin.kit.call:call:4.1.0'
 }

--- a/Android/call-ui/proguard-rules.pro
+++ b/Android/call-ui/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.kts.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/Android/call-ui/src/main/AndroidManifest.xml
+++ b/Android/call-ui/src/main/AndroidManifest.xml
@@ -54,8 +54,23 @@
             android:screenOrientation="portrait"
             android:theme="@style/Theme.AppCompat.NoActionBar" />
 
+        <activity android:name=".permission.PermissionActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:launchMode="singleTask"
+            android:theme="@style/TranslucentStyle"
+            android:windowSoftInputMode="stateHidden|stateAlwaysHidden" />
+
         <service android:name=".service.VideoCallForegroundService" android:foregroundServiceType="microphone|camera"/>
         <service android:name=".service.AudioCallForegroundService" android:foregroundServiceType="microphone"/>
+
+        <service
+            android:name=".service.foregroundservice.AudioForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
+        <service
+            android:name=".service.foregroundservice.VideoForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="camera|microphone" />
 
     </application>
 

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/CallKitUIService.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/CallKitUIService.kt
@@ -25,7 +25,7 @@ class CallKitUIService : XKitService {
         get() = "CallUIKit"
 
     override val versionName: String
-        get() = "3.8.0"
+        get() = BuildConfig.versionName
 
     override val appKey: String?
         get() = null

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/base/CommonCallActivity.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/base/CommonCallActivity.kt
@@ -137,7 +137,13 @@ abstract class CommonCallActivity : AppCompatActivity(), NECallEngineDelegate {
     }
 
     open fun doOnCreate(savedInstanceState: Bundle?) {
-        setContentView(provideLayoutId())
+        if (provideLayoutId() != 0) {
+            setContentView(provideLayoutId())
+        } else if (provideLayoutView() != null) {
+            setContentView(provideLayoutView())
+        } else {
+            throw RuntimeException("provideLayoutId or provideLayoutView must be not null.")
+        }
         // 由于页面启动耗时，可能出现页面启动中通话被挂断，此时需要销毁页面
         if (callParam.isCalled && callEngine.callInfo.callStatus == CallState.STATE_IDLE) {
             releaseAndFinish(false)
@@ -210,7 +216,9 @@ abstract class CommonCallActivity : AppCompatActivity(), NECallEngineDelegate {
         releaseAndFinish(true)
     }
 
-    protected abstract fun provideLayoutId(): Int
+    protected open fun provideLayoutId(): Int { return 0 }
+
+    protected open fun provideLayoutView(): View? { return null }
 
     protected open fun provideUIConfig(callParam: CallParam?): P2PUIConfig? {
         return P2PUIConfig()

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/event/EventManager.java
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/event/EventManager.java
@@ -1,0 +1,120 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.nertc.ui.event;
+
+import android.text.TextUtils;
+import android.util.Pair;
+import com.netease.yunxin.kit.alog.ALog;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class EventManager {
+  private static final String TAG = EventManager.class.getSimpleName();
+  private final Map<Pair<String, String>, List<INotifyEvent>> eventMap;
+
+  public static EventManager getInstance() {
+    return EventManagerHolder.eventManager;
+  }
+
+  private EventManager() {
+    this.eventMap = new ConcurrentHashMap();
+  }
+
+  public void registerEvent(String key, String subKey, INotifyEvent notification) {
+    ALog.i(
+        TAG,
+        "registerEvent : key : "
+            + key
+            + ", subKey : "
+            + subKey
+            + ", notification : "
+            + notification);
+    if (!TextUtils.isEmpty(key) && !TextUtils.isEmpty(subKey) && notification != null) {
+      Pair<String, String> keyPair = new Pair(key, subKey);
+      List<INotifyEvent> list = (List) this.eventMap.get(keyPair);
+      if (list == null) {
+        list = new CopyOnWriteArrayList();
+        this.eventMap.put(keyPair, list);
+      }
+
+      if (!((List) list).contains(notification)) {
+        ((List) list).add(notification);
+      }
+    }
+  }
+
+  public void unRegisterEvent(String key, String subKey, INotifyEvent notification) {
+    ALog.i(
+        TAG,
+        "removeEvent : key : " + key + ", subKey : " + subKey + " notification : " + notification);
+    if (!TextUtils.isEmpty(key) && !TextUtils.isEmpty(subKey) && notification != null) {
+      Pair<String, String> keyPair = new Pair(key, subKey);
+      List<INotifyEvent> list = (List) this.eventMap.get(keyPair);
+      if (list != null) {
+        list.remove(notification);
+      }
+    }
+  }
+
+  public void unRegisterEvent(INotifyEvent notification) {
+    ALog.i(TAG, "removeEvent : notification : " + notification);
+    if (notification != null) {
+      Iterator var2 = this.eventMap.keySet().iterator();
+
+      while (true) {
+        while (true) {
+          List value;
+          do {
+            if (!var2.hasNext()) {
+              return;
+            }
+
+            Pair<String, String> key = (Pair) var2.next();
+            value = (List) this.eventMap.get(key);
+          } while (value == null);
+
+          Iterator var5 = value.iterator();
+
+          while (var5.hasNext()) {
+            INotifyEvent item = (INotifyEvent) var5.next();
+            if (item == notification) {
+              value.remove(item);
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  public void notifyEvent(String key, String subKey, Map<String, Object> param) {
+    ALog.d(TAG, "notifyEvent : key : " + key + ", subKey : " + subKey);
+    if (!TextUtils.isEmpty(key) && !TextUtils.isEmpty(subKey)) {
+      Pair<String, String> keyPair = new Pair(key, subKey);
+      List<INotifyEvent> notificationList = (List) this.eventMap.get(keyPair);
+      if (notificationList != null) {
+        Iterator var6 = notificationList.iterator();
+
+        while (var6.hasNext()) {
+          INotifyEvent notification = (INotifyEvent) var6.next();
+          notification.onNotifyEvent(key, subKey, param);
+        }
+      }
+    }
+  }
+
+  private static class EventManagerHolder {
+    private static final EventManager eventManager = new EventManager();
+
+    private EventManagerHolder() {}
+  }
+
+  public interface INotifyEvent {
+    void onNotifyEvent(String key, String subKey, Map<String, Object> param);
+  }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/floating/FloatingWindowManager.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/floating/FloatingWindowManager.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.floating
+
+import android.app.Activity
+import android.content.Context
+import android.view.View
+import com.netease.yunxin.nertc.ui.p2p.CallUIFloatingWindowMgr
+import com.netease.yunxin.nertc.ui.utils.CallUILog
+import com.netease.yunxin.nertc.ui.view.OverLayPermissionDialog
+
+class FloatingWindowManager {
+    private var overLayPermissionDialog: OverLayPermissionDialog? = null
+
+    companion object {
+        private const val TAG = "FloatingWindowManager"
+        val instance: FloatingWindowManager = FloatingWindowManager()
+    }
+
+    fun startFloatWindow(context: Context) {
+        if (!FloatingPermission.isFloatPermissionValid(context)) {
+            if (overLayPermissionDialog?.isShowing != true) {
+                showOverlayPermissionDialog(context) {
+                    FloatingPermission.requireFloatPermission(context)
+                }
+            }
+            return
+        }
+
+        if (!FloatingPermission.isBackgroundStartAllowed(context)) {
+            if (overLayPermissionDialog?.isShowing != true) {
+                showOverlayPermissionDialog(context) {
+                    FloatingPermission.startToPermissionSetting(context)
+                }
+            }
+            return
+        }
+
+        if (!CallUIFloatingWindowMgr.isFloating()) {
+            CallUIFloatingWindowMgr.showFloat(context)
+        }
+    }
+
+    fun stopFloatWindow() {
+        if (CallUIFloatingWindowMgr.isFloating()) {
+            CallUIFloatingWindowMgr.releaseFloat()
+        }
+    }
+
+    fun showOverlayPermissionDialog(context: Context, clickListener: View.OnClickListener): OverLayPermissionDialog {
+        CallUILog.i(TAG, "show")
+        return OverLayPermissionDialog(context as Activity, clickListener).apply {
+            overLayPermissionDialog = this
+            show()
+        }
+    }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/floating/FloatingWindowObserver.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/floating/FloatingWindowObserver.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.floating
+
+interface FloatingWindowObserver {
+    fun onFloatWindowClick()
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/hybird/CallKitBridge.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/hybird/CallKitBridge.kt
@@ -7,23 +7,45 @@
 package com.netease.yunxin.nertc.ui.hybird
 
 import android.content.Context
+import com.netease.lava.nertc.sdk.NERtcConstants
+import com.netease.lava.nertc.sdk.audio.NERtcAudioAINSMode
 import com.netease.nimlib.sdk.NIMClient
 import com.netease.nimlib.sdk.SDKOptions
 import com.netease.nimlib.sdk.v2.auth.V2NIMLoginService
 import com.netease.yunxin.kit.call.p2p.NECallEngine
+import com.netease.yunxin.kit.call.p2p.model.NECallConfig
 import com.netease.yunxin.kit.call.p2p.model.NECallInfo
+import com.netease.yunxin.kit.call.p2p.model.NECallType
 import com.netease.yunxin.kit.call.p2p.model.NESetupConfig
 import com.netease.yunxin.kit.call.p2p.param.NECallParam
 import com.netease.yunxin.kit.call.p2p.param.NEHangupParam
+import com.netease.yunxin.kit.call.p2p.param.NESwitchParam
 import com.netease.yunxin.kit.common.utils.ThreadUtils.runOnUiThread
+import com.netease.yunxin.nertc.nertcvideocall.model.CallErrorCode
 import com.netease.yunxin.nertc.ui.callback.NECallback
+import com.netease.yunxin.nertc.ui.floating.FloatingWindowObserver
+import com.netease.yunxin.nertc.ui.manager.CallManager
+import com.netease.yunxin.nertc.ui.p2p.CallUIOperationsMgr
+import com.netease.yunxin.nertc.ui.service.foregroundservice.AudioForegroundService
+import com.netease.yunxin.nertc.ui.service.foregroundservice.VideoForegroundService
 import com.netease.yunxin.nertc.ui.utils.CallUILog
+import java.util.concurrent.CountDownLatch
 
 class CallKitBridge {
-
     companion object {
         private const val TAG = "CallBridge"
         val instance: CallKitBridge = CallKitBridge()
+        fun getVersion(): String {
+            CallUILog.i(TAG, "getVersion")
+            var result = ""
+            val latch = CountDownLatch(1)
+            runOnUiThread {
+                result = NECallEngine.getVersion()
+                latch.countDown()
+            }
+            latch.await()
+            return result
+        }
     }
 
     fun init(context: Context, appKey: String, frameWork: String, channel: String, currentUserRtcUid: Long) {
@@ -41,6 +63,7 @@ class CallKitBridge {
                 .currentUserRtcUid(currentUserRtcUid)
                 .build()
             NECallEngine.sharedInstance().setup(context, config)
+            CallUIOperationsMgr.load(context)
         }
     }
 
@@ -91,39 +114,205 @@ class CallKitBridge {
     ) {
         CallUILog.i(TAG, "call")
         runOnUiThread {
-            NECallEngine.sharedInstance().call(params) { result ->
-                if (result?.code == 0) {
-                    callback?.onSuccess(result.data)
-                } else {
-                    callback?.onError(result?.code ?: -1, result?.msg)
-                }
-            }
+            CallManager.instance.call(params, callback)
         }
     }
 
     fun accept(callback: NECallback<NECallInfo>?) {
         CallUILog.i(TAG, "accept")
         runOnUiThread {
-            NECallEngine.sharedInstance().accept { result ->
-                if (result?.code == 0) {
-                    callback?.onSuccess(result.data)
-                } else {
-                    callback?.onError(result?.code ?: -1, result?.msg)
-                }
-            }
+            CallManager.instance.accept(callback)
         }
     }
 
     fun hangup(param: NEHangupParam, callback: NECallback<Void>?) {
         CallUILog.i(TAG, "hangup param = $param")
         runOnUiThread {
-            NECallEngine.sharedInstance().hangup(param) { result ->
-                if (result?.code == 0) {
-                    callback?.onSuccess(result.data)
-                } else {
-                    callback?.onError(result?.code ?: -1, result?.msg)
-                }
-            }
+            CallManager.instance.hangup(param, callback)
         }
+    }
+
+    fun muteLocalAudio(mute: Boolean): Int {
+        CallUILog.i(TAG, "muteLocalAudio mute = $mute")
+        var result: Int = CallErrorCode.COMMON_ERROR
+        val latch = CountDownLatch(1)
+        runOnUiThread {
+            result = CallManager.instance.muteLocalAudio(mute)
+            latch.countDown()
+        }
+        latch.await()
+        return result
+    }
+
+    fun muteLocalVideo(mute: Boolean): Int {
+        CallUILog.i(TAG, "muteLocalVideo mute = $mute")
+        var result: Int = CallErrorCode.COMMON_ERROR
+        val latch = CountDownLatch(1)
+        runOnUiThread {
+            result = CallManager.instance.muteLocalVideo(mute)
+            latch.countDown()
+        }
+        latch.await()
+        return result
+    }
+
+    fun enableLocalVideo(enable: Boolean): Int {
+        CallUILog.i(TAG, "enableLocalVideo enable = $enable")
+        var result: Int = CallErrorCode.COMMON_ERROR
+        val latch = CountDownLatch(1)
+        runOnUiThread {
+            result = CallManager.instance.enableLocalVideo(enable)
+            latch.countDown()
+        }
+        latch.await()
+        return result
+    }
+
+    fun setTimeout(millisecond: Long) {
+        CallUILog.i(TAG, "setTimeout millisecond = $millisecond")
+        runOnUiThread {
+            CallManager.instance.setTimeout(millisecond)
+        }
+    }
+
+    fun switchCallType(param: NESwitchParam, callback: NECallback<Void>?) {
+        CallUILog.i(TAG, "switchCallType param = $param")
+        runOnUiThread {
+            CallManager.instance.switchCallType(param, callback)
+        }
+    }
+
+    fun switchCamera(position: Int? = 0) {
+        CallUILog.i(TAG, "switchCamera position = $position")
+        runOnUiThread {
+            val finalPosition: Int = if (position == 0) {
+                NERtcConstants.CameraPosition.CAMERA_POSITION_FRONT
+            } else {
+                NERtcConstants.CameraPosition.CAMERA_POSITION_BACK
+            }
+            CallManager.instance.switchCamera(finalPosition)
+        }
+    }
+
+    fun setSpeakerphoneOn(enable: Boolean): Int {
+        CallUILog.i(TAG, "setSpeakerphoneOn enable = $enable")
+        var result = CallErrorCode.COMMON_ERROR
+        val latch = CountDownLatch(1)
+        runOnUiThread {
+            result = CallManager.instance.setSpeakerphoneOn(enable)
+            latch.countDown()
+        }
+        latch.await()
+        return result
+    }
+
+    fun isSpeakerphoneOn(): Boolean {
+        CallUILog.i(TAG, "isSpeakerphoneOn")
+        var result = false
+        val latch = CountDownLatch(1)
+        runOnUiThread {
+            result = CallManager.instance.isSpeakerphoneOn()
+            latch.countDown()
+        }
+        latch.await()
+        return result
+    }
+
+    fun setCallConfig(config: NECallConfig) {
+        CallUILog.i(TAG, "setCallConfig config = $config")
+        runOnUiThread {
+            CallManager.instance.setCallConfig(config)
+        }
+    }
+
+    fun getCallConfig(): NECallConfig? {
+        CallUILog.i(TAG, "getCallConfig")
+        var result: NECallConfig? = null
+        val latch = CountDownLatch(1)
+        runOnUiThread {
+            result = CallManager.instance.getCallConfig()
+            latch.countDown()
+        }
+        latch.await()
+        return result
+    }
+
+    fun getCallInfo(): NECallInfo? {
+        CallUILog.i(TAG, "getCallInfo")
+        var result: NECallInfo? = null
+        val latch = CountDownLatch(1)
+        runOnUiThread {
+            result = CallManager.instance.getCallInfo()
+            latch.countDown()
+        }
+        latch.await()
+        return result
+    }
+
+    fun setAINSMode(mode: NERtcAudioAINSMode): Int {
+        CallUILog.i(TAG, "setAINSMode mode = $mode")
+        var result: Int = CallErrorCode.COMMON_ERROR
+        val latch = CountDownLatch(1)
+        runOnUiThread {
+            result = CallManager.instance.setAINSMode(mode)
+            latch.countDown()
+        }
+        latch.await()
+        return result
+    }
+
+    fun destroy() {
+        CallUILog.i(TAG, "destroy")
+        runOnUiThread {
+            CallManager.instance.destroy()
+        }
+    }
+
+    fun addFloatWindowObserver(observer: FloatingWindowObserver) {
+        CallUILog.i(TAG, "addFloatWindowObserver, observer: $observer")
+        runOnUiThread {
+            CallManager.instance.addFloatWindowObserver(observer)
+        }
+    }
+
+    fun removeFloatWindowObserver(observer: FloatingWindowObserver) {
+        CallUILog.i(TAG, "removeFloatWindowObserver, observer: $observer")
+        runOnUiThread {
+            CallManager.instance.removeFloatWindowObserver(observer)
+        }
+    }
+
+    fun startFloatWindow(context: Context) {
+        CallUILog.i(TAG, "startFloatWindow")
+        runOnUiThread {
+            CallManager.instance.startFloatWindow(context)
+        }
+    }
+
+    fun stopFloatWindow() {
+        CallUILog.i(TAG, "stopFloatWindow")
+        runOnUiThread {
+            CallManager.instance.stopFloatWindow()
+        }
+    }
+
+    fun hasPermission(context: Context, callType: Int, callback: NECallback<Void>?) {
+        CallUILog.i(TAG, "hasPermission")
+        runOnUiThread {
+            CallManager.instance.hasPermission(context, callType, callback)
+        }
+    }
+
+    fun startForegroundService(context: Context, callType: Int, title: String, description: String) {
+        if (callType == NECallType.VIDEO) {
+            VideoForegroundService.start(context, title, description, 0)
+        } else if (callType == NECallType.AUDIO) {
+            AudioForegroundService.start(context, title, description, 0)
+        }
+    }
+
+    fun stopForegroundService(context: Context) {
+        VideoForegroundService.stop(context)
+        AudioForegroundService.stop(context)
     }
 }

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/hybird/FloatingWindowManager.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/hybird/FloatingWindowManager.kt
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.hybird
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.view.View
+import android.view.WindowManager
+import com.netease.yunxin.kit.alog.ParameterMap
+import com.netease.yunxin.kit.call.p2p.NECallEngine
+import com.netease.yunxin.kit.call.p2p.model.NECallEndInfo
+import com.netease.yunxin.kit.call.p2p.model.NECallEngineDelegateAbs
+import com.netease.yunxin.kit.call.p2p.model.NECallType
+import com.netease.yunxin.kit.call.p2p.model.NECallTypeChangeInfo
+import com.netease.yunxin.kit.call.p2p.model.NEHangupReasonCode
+import com.netease.yunxin.nertc.nertcvideocall.model.SwitchCallState
+import com.netease.yunxin.nertc.ui.base.CallParam
+import com.netease.yunxin.nertc.ui.base.Constants
+import com.netease.yunxin.nertc.ui.base.launchTask
+import com.netease.yunxin.nertc.ui.floating.FloatingTouchEventStrategy
+import com.netease.yunxin.nertc.ui.floating.FloatingWindowObserver
+import com.netease.yunxin.nertc.ui.floating.FloatingWindowWrapper
+import com.netease.yunxin.nertc.ui.p2p.CallUIOperationsMgr
+import com.netease.yunxin.nertc.ui.p2p.FloatingView
+import com.netease.yunxin.nertc.ui.p2p.IFloatingView
+import com.netease.yunxin.nertc.ui.p2p.P2PUIConfig
+import com.netease.yunxin.nertc.ui.utils.CallUILog
+import com.netease.yunxin.nertc.ui.utils.CallUIUtils
+import com.netease.yunxin.nertc.ui.utils.SwitchCallTypeConfirmDialog
+
+object FloatingWindowManager {
+
+    private const val TAG = "FloatingWindowManager"
+    private const val REQUEST_CODE_FLOAT = 21301
+
+    private var floatContentView: IFloatingView? = null
+    private var floatingWindowWrapper: FloatingWindowWrapper? = null
+    private var dialog: SwitchCallTypeConfirmDialog? = null
+    private var dialogFlag: Any? = null
+
+    /**
+     * 用于用户展示自己的切换弹窗样式
+     */
+    private var switchCallTypeConfirmDialogProvider: ((Activity) -> SwitchCallTypeConfirmDialog?)? = null
+
+    /**
+     * 浮窗观察者列表
+     */
+    private val observers = mutableListOf<FloatingWindowObserver>()
+
+    /**
+     * 配置通话结束及通话类型变化监听
+     */
+    private val delegate = object : NECallEngineDelegateAbs() {
+        override fun onCallTypeChange(info: NECallTypeChangeInfo?) {
+            super.onCallTypeChange(info)
+            info ?: return
+
+            if (info.state == SwitchCallState.INVITE && dialog?.isShowing != true) {
+                showSwitchCallTypeConfirmDialog(info)
+                return
+            }
+
+            if (info.state != SwitchCallState.ACCEPT) {
+                return
+            }
+            if (info.callType == NECallType.VIDEO) {
+                // 视频
+                CallUIOperationsMgr.doMuteVideo(false)
+                // 扬声器
+                CallUIOperationsMgr.doConfigSpeaker(true)
+                // 音频
+                CallUIOperationsMgr.doMuteAudio(false)
+                // 背景虚化
+                CallUIOperationsMgr.doVirtualBlur(false)
+            } else {
+                // 视频
+                CallUIOperationsMgr.doMuteVideo(true)
+                // 扬声器
+                CallUIOperationsMgr.doConfigSpeaker(false)
+                // 音频
+                CallUIOperationsMgr.doMuteAudio(false)
+                // 背景虚化
+                CallUIOperationsMgr.doVirtualBlur(false)
+            }
+            // 初始化状态，不同通话类型
+            if (info.callType == NECallType.AUDIO) {
+                floatContentView?.transToAudioUI()
+            } else if (info.callType == NECallType.VIDEO) {
+                floatContentView?.transToVideoUI()
+            }
+            // 用于浮窗在左侧时变化ui时浮窗没有吸附
+            floatingWindowWrapper?.toUpdateViewContent()
+        }
+
+        override fun onCallEnd(info: NECallEndInfo?) {
+            super.onCallEnd(info)
+            floatingWindowWrapper?.let {
+                CallUIUtils.showToastWithCallEndReason(
+                    it.context,
+                    info?.reasonCode ?: NEHangupReasonCode.NORMAL
+                )
+            }
+
+            innerRelease(true)
+        }
+    }
+
+// -----------------------------------------------------
+
+    /**
+     * 展示悬浮窗
+     *
+     * @param context 上下文
+     */
+    @JvmOverloads
+    fun showFloat(
+        context: Context,
+        uiConfig: P2PUIConfig? = null,
+        floatingView: IFloatingView? = null,
+        windowLayoutParams: WindowManager.LayoutParams? = null,
+        touchEventStrategy: FloatingTouchEventStrategy? = null
+
+    ) {
+        CallUILog.dApi(
+            TAG,
+            ParameterMap("showFloat").append("context", context).append("uiConfig", uiConfig)
+        )
+        NECallEngine.sharedInstance().addCallDelegate(delegate)
+        if (floatingView != null && floatingView !is View) {
+            throw IllegalArgumentException("floatingView$floatingView must be a view instance.")
+        }
+        floatContentView = floatingView ?: FloatingView(context)
+        if (floatContentView is View) {
+            registerFullScreenActionForView(context, floatContentView as View)
+        }
+
+        val builder = FloatingWindowWrapper.Builder()
+            .windowYPos(400)
+        windowLayoutParams?.run {
+            builder.windowLayoutParams(this)
+        }
+        touchEventStrategy?.run {
+            builder.touchEventStrategy(this)
+        }
+        floatingWindowWrapper = builder.build(context)
+            .apply {
+                showView(floatContentView as View)
+            }
+        floatContentView?.run {
+            toInit()
+            when (NECallEngine.sharedInstance().callInfo.callType) {
+                NECallType.AUDIO -> {
+                    transToAudioUI()
+                }
+
+                NECallType.VIDEO -> {
+                    transToVideoUI()
+                }
+
+                else -> {
+                    CallUILog.e(TAG, "unknown call type")
+                }
+            }
+        }
+        // 避免在全屏/小窗切换时丢失音视频切换弹窗
+        val info = CallUIOperationsMgr.currentSwitchTypeCallInfo() ?: return
+        if (dialog?.isShowing == true || info.state != SwitchCallState.INVITE) {
+            return
+        }
+        showSwitchCallTypeConfirmDialog(info)
+    }
+
+    fun registerFullScreenActionForView(context: Context, view: View) {
+        view.setOnClickListener {
+            notifyObservers()
+        }
+    }
+
+    /**
+     * 配置音视频通话切换确认弹窗
+     */
+    fun configSwitchCallTypeConfirmDialogProvider(provider: (Activity) -> SwitchCallTypeConfirmDialog?) {
+        this.switchCallTypeConfirmDialogProvider = provider
+    }
+
+    /**
+     * 注册浮窗观察者
+     *
+     * @param observer 观察者
+     */
+    fun addFloatWindowObserver(observer: FloatingWindowObserver) {
+        if (!observers.contains(observer)) {
+            observers.add(observer)
+            CallUILog.d(TAG, "registerObserver: ${observer.javaClass.simpleName}")
+        }
+    }
+
+    /**
+     * 取消注册浮窗观察者
+     *
+     * @param observer 观察者
+     */
+    fun removeFloatWindowObserver(observer: FloatingWindowObserver) {
+        if (observers.remove(observer)) {
+            CallUILog.d(TAG, "unregisterObserver: ${observer.javaClass.simpleName}")
+        }
+    }
+
+    /**
+     * 通知所有观察者浮窗被点击
+     */
+    private fun notifyObservers() {
+        observers.forEach { observer ->
+            try {
+                observer.onFloatWindowClick()
+            } catch (e: Exception) {
+                CallUILog.e(TAG, "notifyObserver error: ${observer.javaClass.simpleName}", e)
+            }
+        }
+    }
+
+    /**
+     * 销毁悬浮窗
+     */
+    fun releaseFloat(isFinished: Boolean = true) {
+        CallUILog.dApi(TAG, ParameterMap("releaseFloat"))
+        innerRelease(isFinished)
+    }
+
+    /**
+     * 是否正在展示浮窗
+     */
+    fun isFloating(): Boolean {
+        return floatingWindowWrapper != null
+    }
+
+    /**
+     * 展示音视频切换确认弹窗
+     */
+    private fun showSwitchCallTypeConfirmDialog(info: NECallTypeChangeInfo) {
+        if (dialogFlag != null) {
+            return
+        }
+        dialogFlag = Any()
+        floatingWindowWrapper?.context?.run {
+            launchTask(this, REQUEST_CODE_FLOAT, { activity, _ ->
+                CallUILog.d(TAG, "showSwitchCallTypeConfirmDialog")
+                dialog =
+                    switchCallTypeConfirmDialogProvider?.invoke(activity) ?: SwitchCallTypeConfirmDialog(
+                        activity,
+                        {
+                            CallUIOperationsMgr.doSwitchCallType(
+                                info.callType,
+                                SwitchCallState.ACCEPT,
+                                null
+                            )
+                        },
+                        {
+                            CallUIOperationsMgr.doSwitchCallType(
+                                info.callType,
+                                SwitchCallState.REJECT,
+                                null
+                            )
+                        }
+                    ).apply {
+                        setOnDismissListener {
+                            activity.finish()
+                        }
+                        show(info.callType)
+                        val latestInfo = CallUIOperationsMgr.currentSwitchTypeCallInfo()
+                        if (latestInfo?.state != SwitchCallState.INVITE) {
+                            dismiss()
+                        }
+                    }
+                dialogFlag = null
+            }, {})
+        }
+    }
+
+    private fun innerRelease(isFinished: Boolean) {
+        CallUILog.d(TAG, ParameterMap("innerRelease").toValue())
+        NECallEngine.sharedInstance().removeCallDelegate(delegate)
+        CallUIOperationsMgr.configTimeTick(null)
+        floatContentView?.toDestroy(isFinished)
+        floatingWindowWrapper?.dismissView()
+        floatingWindowWrapper = null
+        dialog?.dismiss()
+        dialog = null
+        dialogFlag = null
+        observers.clear()
+    }
+
+    /**
+     * 启动对应页面
+     */
+    private fun launch(
+        context: Context,
+        clazz: Class<out Activity>,
+        callParam: CallParam
+    ) {
+        CallUILog.dApi(
+            TAG,
+            ParameterMap("launch")
+                .append("context", context)
+                .append("callParam", callParam)
+        )
+        val intent = Intent(context, clazz).apply {
+            putExtra(Constants.PARAM_KEY_CALL, callParam)
+            if (context !is Activity) {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            putExtra(Constants.PARAM_KEY_FLAG_IS_FROM_FLOATING_WINDOW, true)
+        }
+        context.startActivity(intent)
+    }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/manager/CallManager.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/manager/CallManager.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.manager
+
+import android.content.Context
+import com.netease.lava.api.IVideoRender
+import com.netease.lava.nertc.sdk.NERtcEx
+import com.netease.lava.nertc.sdk.audio.NERtcAudioAINSMode
+import com.netease.yunxin.kit.call.p2p.NECallEngine
+import com.netease.yunxin.kit.call.p2p.model.NECallConfig
+import com.netease.yunxin.kit.call.p2p.model.NECallInfo
+import com.netease.yunxin.kit.call.p2p.param.NECallParam
+import com.netease.yunxin.kit.call.p2p.param.NEHangupParam
+import com.netease.yunxin.kit.call.p2p.param.NESwitchParam
+import com.netease.yunxin.nertc.nertcvideocall.model.CallErrorCode
+import com.netease.yunxin.nertc.ui.callback.NECallback
+import com.netease.yunxin.nertc.ui.floating.FloatingWindowObserver
+import com.netease.yunxin.nertc.ui.hybird.FloatingWindowManager
+import com.netease.yunxin.nertc.ui.permission.PermissionCallback
+import com.netease.yunxin.nertc.ui.permission.PermissionRequest
+import com.netease.yunxin.nertc.ui.permission.PermissionRequester
+import com.netease.yunxin.nertc.ui.utils.CallUILog
+
+class CallManager {
+    var callParams: NECallParam? = null
+    var isLocalMuteAudio = false
+    var isLocalMuteVideo = false
+
+    fun setupLocalView(videoRender: IVideoRender) {
+        CallUILog.i(TAG, "setupLocalView videoRender = $videoRender")
+        videoRender.setScalingType(IVideoRender.ScalingType.SCALE_ASPECT_BALANCED)
+        NECallEngine.sharedInstance().setupLocalView(videoRender)
+    }
+
+    fun setupRemoteView(videoRender: IVideoRender) {
+        CallUILog.i(TAG, "setupRemoteView videoRender = $videoRender")
+        videoRender.setScalingType(IVideoRender.ScalingType.SCALE_ASPECT_BALANCED)
+        NECallEngine.sharedInstance().setupRemoteView(videoRender)
+    }
+
+    fun call(params: NECallParam, callback: NECallback<NECallInfo>?) {
+        CallUILog.i(TAG, "call")
+        this.callParams = params
+        NECallEngine.sharedInstance().call(params) { result ->
+            if (result?.code == 0) {
+                callback?.onSuccess(result.data)
+            } else {
+                callback?.onError(result?.code ?: -1, result?.msg)
+            }
+        }
+    }
+
+    fun accept(callback: NECallback<NECallInfo>?) {
+        CallUILog.i(TAG, "accept")
+        NECallEngine.sharedInstance().accept { result ->
+            if (result?.code == 0) {
+                callback?.onSuccess(result.data)
+            } else {
+                callback?.onError(result?.code ?: -1, result?.msg)
+            }
+        }
+    }
+
+    fun hangup(param: NEHangupParam, callback: NECallback<Void>?) {
+        CallUILog.i(TAG, "hangup param = $param")
+        NECallEngine.sharedInstance().hangup(param) { result ->
+            if (result?.code == 0) {
+                callback?.onSuccess(result.data)
+            } else {
+                callback?.onError(result?.code ?: -1, result?.msg)
+            }
+        }
+    }
+
+    fun muteLocalAudio(mute: Boolean): Int {
+        CallUILog.i(TAG, "muteLocalAudio mute = $mute")
+        val result = NECallEngine.sharedInstance().muteLocalAudio(mute)
+        if (result == 0) {
+            isLocalMuteAudio = mute
+        }
+        CallUILog.i(TAG, "muteLocalAudio mute = $mute result = $result")
+        return result
+    }
+
+    fun muteLocalVideo(mute: Boolean): Int {
+        CallUILog.i(TAG, "muteLocalVideo mute = $mute")
+        val result = NECallEngine.sharedInstance().muteLocalVideo(mute)
+        if (result == 0) {
+            isLocalMuteVideo = mute
+        }
+        CallUILog.i(TAG, "muteLocalVideo mute = $mute result = $result")
+        return result
+    }
+
+    fun enableLocalVideo(enable: Boolean): Int {
+        CallUILog.i(TAG, "enableLocalVideo enable = $enable")
+        val result = NECallEngine.sharedInstance().enableLocalVideo(enable)
+        CallUILog.i(TAG, "enableLocalVideo enable = $enable result = $result")
+        return result
+    }
+
+    fun setTimeout(millisecond: Long) {
+        CallUILog.i(TAG, "setTimeout millisecond = $millisecond")
+        NECallEngine.sharedInstance().setTimeout(millisecond)
+    }
+
+    fun switchCallType(param: NESwitchParam, callback: NECallback<Void>?) {
+        CallUILog.i(TAG, "switchCallType param = $param")
+        NECallEngine.sharedInstance().switchCallType(
+            param
+        ) { result ->
+            if (result?.code == 0) {
+                callback?.onSuccess(result.data)
+            } else {
+                callback?.onError(result?.code ?: -1, result?.msg)
+            }
+        }
+    }
+
+    fun switchCamera(position: Int) {
+        CallUILog.i(TAG, "switchCamera position = $position")
+        NERtcEx.getInstance().switchCameraWithPosition(position)
+    }
+
+    fun setSpeakerphoneOn(enable: Boolean): Int {
+        CallUILog.i(TAG, "setSpeakerphoneOn enable = $enable")
+        return NECallEngine.sharedInstance().setSpeakerphoneOn(enable)
+    }
+
+    fun isSpeakerphoneOn(): Boolean {
+        CallUILog.i(TAG, "isSpeakerphoneOn")
+        return NECallEngine.sharedInstance().isSpeakerphoneOn()
+    }
+
+    fun setCallConfig(config: NECallConfig) {
+        CallUILog.i(TAG, "setCallConfig config = $config")
+        NECallEngine.sharedInstance().callConfig = config
+    }
+
+    fun getCallConfig(): NECallConfig? {
+        CallUILog.i(TAG, "getCallConfig")
+        return NECallEngine.sharedInstance().callConfig
+    }
+
+    fun getCallInfo(): NECallInfo? {
+        CallUILog.i(TAG, "getCallInfo")
+        return NECallEngine.sharedInstance().callInfo
+    }
+
+    fun setAINSMode(mode: NERtcAudioAINSMode): Int {
+        CallUILog.i(TAG, "setAINSMode mode = $mode")
+        return NECallEngine.sharedInstance().setAINSMode(mode)
+    }
+
+    fun destroy() {
+        CallUILog.i(TAG, "destroy")
+        NECallEngine.sharedInstance().destroy()
+    }
+
+    fun addFloatWindowObserver(observer: FloatingWindowObserver) {
+        CallUILog.i(TAG, "addFloatWindowObserver, observer: $observer")
+        FloatingWindowManager.addFloatWindowObserver(observer)
+    }
+
+    fun removeFloatWindowObserver(observer: FloatingWindowObserver) {
+        CallUILog.i(TAG, "removeFloatWindowObserver, observer: $observer")
+        FloatingWindowManager.removeFloatWindowObserver(observer)
+    }
+
+    fun startFloatWindow(context: Context) {
+        CallUILog.i(TAG, "startFloatWindow")
+        if (FloatingWindowManager.isFloating()) {
+            CallUILog.i(TAG, "There is already a floatWindow on display, do not open it again.")
+            return
+        }
+
+        if (PermissionRequester.newInstance(PermissionRequester.FLOAT_PERMISSION).has()) {
+            FloatingWindowManager.showFloat(context)
+        } else {
+            PermissionRequester.newInstance(PermissionRequester.FLOAT_PERMISSION).request()
+        }
+    }
+
+    fun stopFloatWindow() {
+        CallUILog.i(TAG, "stopFloatWindow")
+        if (FloatingWindowManager.isFloating()) {
+            FloatingWindowManager.releaseFloat()
+        }
+    }
+
+    fun hasPermission(context: Context, callType: Int?, callback: NECallback<Void>?) {
+        CallUILog.i(TAG, "hasPermission")
+        if (callType == null) {
+            callback?.onError(CallErrorCode.COMMON_ERROR, "callType is null")
+            return
+        }
+
+        PermissionRequest.requestPermissions(
+            context,
+            callType,
+            object : PermissionCallback() {
+                override fun onGranted() {
+                    callback?.onSuccess(null)
+                }
+
+                override fun onDenied() {
+                    callback?.onError(-1, "Permission denied")
+                }
+            }
+        )
+    }
+
+    companion object {
+        private const val TAG = "CallManager"
+        val instance: CallManager = CallManager()
+    }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/ActivityFloatingView.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/ActivityFloatingView.kt
@@ -48,15 +48,15 @@ class ActivityFloatingView : FrameLayout {
 
     private fun inflateAndInit(context: Context): ActivityFloatingWindowBinding {
         val b = ActivityFloatingWindowBinding.inflate(LayoutInflater.from(context), this, true)
-        b.tvRemoteVideoCloseTip.visibility = View.GONE
+        b.tvSmallVideoCloseTip.visibility = View.GONE
         b.videoViewSmall.visibility = View.VISIBLE
         return b
     }
 
     fun changeMuteVideo(isSelf: Boolean, mute: Boolean) {
-        binding.tvRemoteVideoCloseTip.visibility = if (mute) View.VISIBLE else View.GONE
+        binding.tvSmallVideoCloseTip.visibility = if (mute) View.VISIBLE else View.GONE
         binding.videoViewSmall.visibility = if (mute) View.GONE else View.VISIBLE
-        binding.tvRemoteVideoCloseTip.text = if (isSelf) { context.getString(
+        binding.tvSmallVideoCloseTip.text = if (isSelf) { context.getString(
             R.string.ui_tip_close_camera_by_self
         ) } else { context.getString(R.string.ui_tip_close_camera_by_other) }
     }

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/CallUIFloatingWindowMgr.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/CallUIFloatingWindowMgr.kt
@@ -132,6 +132,9 @@ object CallUIFloatingWindowMgr {
             throw IllegalArgumentException("floatingView$floatingView must be a view instance.")
         }
         floatContentView = floatingView ?: FloatingView(context)
+        if (floatContentView is View) {
+            registerFullScreenActionForView(context, floatContentView as View)
+        }
         val builder = FloatingWindowWrapper.Builder()
             .windowYPos(400)
         windowLayoutParams?.run {

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/FloatingView.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/FloatingView.kt
@@ -58,7 +58,6 @@ class FloatingView(context: Context) : FrameLayout(context), IFloatingView {
                 postCountDownTxt(timestamp.formatSecondTime())
             })
         )
-        CallUIFloatingWindowMgr.registerFullScreenActionForView(context, this)
     }
 
     override fun transToAudioUI() {
@@ -91,8 +90,9 @@ class FloatingView(context: Context) : FrameLayout(context), IFloatingView {
             binding.floatAudioGroup.visibility = View.GONE
             binding.ivAvatar.visibility = View.VISIBLE
             binding.videoBg.visibility = View.VISIBLE
-            if (CallUIOperationsMgr.currentCallState() == CallState.STATE_DIALOG) {
-                val isVideoing = !CallUIOperationsMgr.callInfoWithUIState.isRemoteMuteVideo
+            val callInfo = NECallEngine.sharedInstance().callInfo
+            if (callInfo.callStatus == CallState.STATE_DIALOG) {
+                val isVideoing = !callInfo.otherUserInfo().isMuteVideo
                 if (isVideoing) {
                     binding.videoViewSmall.visibility = View.VISIBLE
                     CallUIOperationsMgr.setupRemoteView(binding.videoViewSmall)
@@ -104,8 +104,12 @@ class FloatingView(context: Context) : FrameLayout(context), IFloatingView {
                 CallUIOperationsMgr.setupLocalView(binding.videoViewSmall)
                 CallUIOperationsMgr.startVideoPreview()
             }
-            CallUIOperationsMgr.callInfoWithUIState.callParam.otherAccId
-                ?.loadAvatarByAccId(context, binding.ivAvatar, enableTextDefaultAvatar = false)
+
+            callInfo?.otherUserInfo()?.accId?.loadAvatarByAccId(
+                context,
+                binding.ivAvatar,
+                enableTextDefaultAvatar = false
+            )
             binding.root.radius = 0f
         }
         if (context.isGranted(RECORD_AUDIO, CAMERA)) {

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/P2PCallActivity.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/P2PCallActivity.kt
@@ -8,21 +8,16 @@ package com.netease.yunxin.nertc.ui.p2p
 
 import android.Manifest
 import android.content.DialogInterface
-import android.graphics.Color
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.ConstraintSet
-import androidx.core.content.ContextCompat
 import com.bumptech.glide.Glide
 import com.netease.lava.nertc.sdk.NERtcConstants
 import com.netease.lava.nertc.sdk.NERtcConstants.ErrorCode.ENGINE_ERROR_DEVICE_PREVIEW_ALREADY_STARTED
 import com.netease.lava.nertc.sdk.NERtcEx
-import com.netease.nimlib.sdk.NIMClient
 import com.netease.nimlib.sdk.ResponseCode
 import com.netease.yunxin.kit.call.NEResultObserver
 import com.netease.yunxin.kit.call.p2p.model.NECallEndInfo
@@ -37,18 +32,15 @@ import com.netease.yunxin.nertc.nertcvideocall.utils.NetworkUtils
 import com.netease.yunxin.nertc.ui.CallKitUI
 import com.netease.yunxin.nertc.ui.R
 import com.netease.yunxin.nertc.ui.base.CommonCallActivity
-import com.netease.yunxin.nertc.ui.base.currentUserIsCaller
-import com.netease.yunxin.nertc.ui.base.fetchNickname
-import com.netease.yunxin.nertc.ui.base.loadAvatarByAccId
 import com.netease.yunxin.nertc.ui.databinding.ActivityP2PcallBinding
 import com.netease.yunxin.nertc.ui.utils.CallUILog
 import com.netease.yunxin.nertc.ui.utils.CallUIUtils
 import com.netease.yunxin.nertc.ui.utils.PermissionTipDialog
-import com.netease.yunxin.nertc.ui.utils.dip2Px
 import com.netease.yunxin.nertc.ui.utils.formatSecondTime
 import com.netease.yunxin.nertc.ui.utils.isGranted
 import com.netease.yunxin.nertc.ui.utils.requestPermission
 import com.netease.yunxin.nertc.ui.utils.toastShort
+import com.netease.yunxin.nertc.ui.view.P2PVideoCallLayout
 
 open class P2PCallActivity : CommonCallActivity() {
     private val tag = "P2PCallActivity"
@@ -60,12 +52,11 @@ open class P2PCallActivity : CommonCallActivity() {
     private var localIsSmallVideo = true
 
     private lateinit var binding: ActivityP2PcallBinding
+    private lateinit var p2PVideoCallLayout: P2PVideoCallLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
         binding = ActivityP2PcallBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        super.onCreate(savedInstanceState)
     }
 
     private val onClickListener = View.OnClickListener { v ->
@@ -109,8 +100,9 @@ open class P2PCallActivity : CommonCallActivity() {
             binding.ivCallSpeaker,
             binding.ivMuteSpeaker -> doConfigSpeakerSwitch(v as ImageView)
 
-            binding.videoViewSmall -> doSwitchCanvas()
-            else -> CallUILog.d(tag, "can't response this clicked Event for $v")
+            else -> {
+                CallUILog.d(tag, "can't response this clicked Event for $v")
+            }
         }
     }
 
@@ -131,7 +123,11 @@ open class P2PCallActivity : CommonCallActivity() {
 
         configTimeTick(
             CallUIOperationsMgr.TimeTickConfig({
-                runOnUiThread { binding.tvCountdown.text = it.formatSecondTime() }
+                runOnUiThread {
+                    if (callParam.callType == NECallType.VIDEO) {
+                        binding.tvCountdown.text = it.formatSecondTime()
+                    }
+                }
             })
         )
     }
@@ -180,18 +176,17 @@ open class P2PCallActivity : CommonCallActivity() {
         if (isFinishing) {
             return
         }
-        uiRender.updateOnTheCallState(UserState(userId, muteVideo = !available))
     }
 
     override fun onVideoMuted(userId: String?, mute: Boolean) {
         if (isFinishing) {
             return
         }
-        uiRender.updateOnTheCallState(UserState(userId, muteVideo = mute))
     }
 
     override fun doOnCreate(savedInstanceState: Bundle?) {
         super.doOnCreate(savedInstanceState)
+        p2PVideoCallLayout = binding.singleVideoCallLayout
         CallUILog.d(tag, callParam.toString())
         initForLaunchUI()
         val dialog: PermissionTipDialog?
@@ -249,7 +244,9 @@ open class P2PCallActivity : CommonCallActivity() {
         }, Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
     }
 
-    override fun provideLayoutId(): Int = R.layout.activity_p2_pcall
+    override fun provideLayoutView(): View? {
+        return binding.root
+    }
 
     override fun releaseAndFinish(finishCall: Boolean) {
         super.releaseAndFinish(false)
@@ -309,15 +306,16 @@ open class P2PCallActivity : CommonCallActivity() {
             return
         }
         doCall()
-        if (CallKitUI.options?.initRtcMode != NECallInitRtcMode.GLOBAL) {
-            setupLocalView(binding.videoViewPreview)
-        }
-        if (callParam.callType == NECallType.VIDEO &&
-            CallKitUI.options?.joinRtcWhenCall == false &&
-            startPreviewCode != NERtcConstants.ErrorCode.OK
-        ) {
-            startPreviewCode = NERtcEx.getInstance().startVideoPreview().apply {
-                CallUILog.d(tag, "initForLaunchAction startPreviewCode is $this.")
+        if (callParam.callType == NECallType.VIDEO) {
+            if (CallKitUI.options?.initRtcMode != NECallInitRtcMode.GLOBAL) {
+                CallUIOperationsMgr.setupLocalView(p2PVideoCallLayout.binding.videoViewPreview)
+            }
+            if (CallKitUI.options?.joinRtcWhenCall == false &&
+                startPreviewCode != NERtcConstants.ErrorCode.OK
+            ) {
+                startPreviewCode = NERtcEx.getInstance().startVideoPreview().apply {
+                    CallUILog.d(tag, "initForLaunchAction startPreviewCode is $this.")
+                }
             }
         }
     }
@@ -360,12 +358,6 @@ open class P2PCallActivity : CommonCallActivity() {
     private fun doMuteVideo(view: ImageView) {
         doMuteVideo()
         view.setImageResource(if (isLocalMuteVideo) R.drawable.cam_off else R.drawable.cam_on)
-        uiRender.updateOnTheCallState(
-            UserState(
-                callParam.currentAccId!!,
-                muteVideo = isLocalMuteVideo
-            )
-        )
     }
 
     private fun doConfigSpeakerSwitch(
@@ -425,44 +417,6 @@ open class P2PCallActivity : CommonCallActivity() {
         )
     }
 
-    private fun doSwitchCanvas() {
-        if (uiConfig?.enableCanvasSwitch == false) {
-            return
-        }
-
-        val rtcUid = callEngine.callInfo.otherUserInfo().uid
-        if (rtcUid == 0L) {
-            CallUILog.e(tag, "doSwitchCanvas rtcUid is 0L with accId ${callParam.otherAccId}.")
-            return
-        }
-        if (isLocalMuteVideo) {
-            binding.videoViewBig.clearImage()
-            binding.videoViewSmall.clearImage()
-        }
-
-        if (localIsSmallVideo) {
-            NERtcEx.getInstance().setupRemoteVideoCanvas(binding.videoViewSmall, rtcUid)
-            NERtcEx.getInstance().setupLocalVideoCanvas(binding.videoViewBig)
-        } else {
-            NERtcEx.getInstance().setupRemoteVideoCanvas(binding.videoViewBig, rtcUid)
-            NERtcEx.getInstance().setupLocalVideoCanvas(binding.videoViewSmall)
-        }
-        localIsSmallVideo = !localIsSmallVideo
-
-        uiRender.updateOnTheCallState(
-            UserState(
-                callParam.currentAccId,
-                muteVideo = isLocalMuteVideo
-            )
-        )
-        uiRender.updateOnTheCallState(
-            UserState(
-                callParam.otherAccId,
-                muteVideo = isRemoteMuteVideo
-            )
-        )
-    }
-
     private open inner class UIRender {
         open fun renderForCaller() {
             binding.tvSwitchTipClose.setOnClickListener {
@@ -486,6 +440,8 @@ open class P2PCallActivity : CommonCallActivity() {
             }
             binding.callerSwitchGroup.visibility = View.GONE
             binding.calledSwitchGroup.visibility = View.GONE
+            binding.tvConnectingTip.visibility = View.GONE
+            binding.tvCountdown.visibility = View.VISIBLE
             if (this is AudioRender) {
                 binding.ivCallChannelTypeChange.visibility =
                     if (uiConfig?.showAudio2VideoSwitchOnTheCall == true) View.VISIBLE else View.GONE
@@ -507,26 +463,18 @@ open class P2PCallActivity : CommonCallActivity() {
                 )
             }
         }
-
-        open fun updateOnTheCallState(state: UserState) {}
     }
 
     private inner class AudioRender : UIRender() {
         override fun renderForCaller() {
             super.renderForCaller()
-            forUserInfoUI(NECallType.AUDIO, callParam.calledAccId, forVideoCaller = true)
             doConfigSpeakerSwitch(speakerEnable = false)
 
             if (isLocalMuteAudio) {
                 doMuteAudioSwitch()
             }
 
-            binding.ivBg.visibility = View.VISIBLE
             binding.tvCallSwitchTypeDesc.setText(R.string.tip_switch_to_video)
-
-            binding.videoViewBig.visibility = View.GONE
-            binding.videoViewPreview.visibility = View.GONE
-            binding.videoViewSmall.visibility = View.GONE
 
             binding.llOnTheCallOperation.visibility = View.GONE
             binding.calledOperationGroup.visibility = View.GONE
@@ -540,7 +488,6 @@ open class P2PCallActivity : CommonCallActivity() {
 
             binding.ivCallMuteAudio.setOnClickListener(onClickListener)
             binding.ivCallSpeaker.setOnClickListener(onClickListener)
-            binding.ivBg.visibility = View.VISIBLE
             if (startPreviewCode == 0 || startPreviewCode == ENGINE_ERROR_DEVICE_PREVIEW_ALREADY_STARTED) {
                 NERtcEx.getInstance().setupLocalVideoCanvas(null)
                 startPreviewCode = if (NERtcEx.getInstance().stopVideoPreview() == 0) -1 else 0
@@ -549,16 +496,9 @@ open class P2PCallActivity : CommonCallActivity() {
 
         override fun renderForCalled() {
             super.renderForCalled()
-            forUserInfoUI(NECallType.AUDIO, NIMClient.getCurrentAccount())
-
             binding.ivAccept.setImageResource(R.drawable.icon_call_audio_accept)
             binding.ivSwitchType.setImageResource(R.drawable.icon_call_tip_audio_to_video)
-            binding.tvOtherCallTip.setText(R.string.tip_invite_to_audio_call)
             binding.tvSwitchTypeDesc.setText(R.string.tip_switch_to_video)
-
-            binding.videoViewPreview.visibility = View.GONE
-            binding.videoViewBig.visibility = View.GONE
-            binding.videoViewSmall.visibility = View.GONE
 
             binding.llOnTheCallOperation.visibility = View.GONE
             binding.calledOperationGroup.visibility = View.VISIBLE
@@ -568,28 +508,15 @@ open class P2PCallActivity : CommonCallActivity() {
             binding.ivAccept.setOnClickListener(onClickListener)
             binding.ivReject.setOnClickListener(onClickListener)
             binding.ivSwitchType.setOnClickListener(onClickListener)
-            binding.ivBg.visibility = View.VISIBLE
         }
 
         override fun renderForOnTheCall(userAccId: String?) {
             super.renderForOnTheCall(userAccId)
 
-            callParam.run {
-                forUserInfoUI(NECallType.AUDIO, otherAccId)
-            }
-
-            binding.tvOtherCallTip.setText(R.string.tip_on_the_call)
-            binding.tvConnectingTip.visibility = View.GONE
-            binding.videoViewPreview.visibility = View.GONE
-            binding.videoViewSmall.visibility = View.GONE
-            binding.videoViewBig.visibility = View.GONE
-            binding.ivSmallVideoShade.visibility = View.GONE
-
             binding.calledOperationGroup.visibility = View.GONE
             binding.callerOperationGroup.visibility = View.GONE
             binding.callerAudioOperationGroup.visibility = View.GONE
             binding.llOnTheCallOperation.visibility = View.VISIBLE
-            binding.tvCountdown.visibility = View.VISIBLE
 
             binding.ivCallChannelTypeChange.setImageResource(R.drawable.audio_to_video)
             binding.ivCallChannelTypeChange.setOnClickListener(onClickListener)
@@ -600,8 +527,6 @@ open class P2PCallActivity : CommonCallActivity() {
 
             binding.ivSwitchCamera.visibility = View.GONE
 
-            binding.tvRemoteVideoCloseTip.visibility = View.GONE
-            binding.ivSmallVideoShade.visibility = View.GONE
             if (!firstLaunch || callParam.isCalled) {
                 resetSwitchState(NECallType.AUDIO)
             } else {
@@ -611,7 +536,6 @@ open class P2PCallActivity : CommonCallActivity() {
             if (!callParam.isCalled) {
                 doConfigSpeakerSwitch(speakerEnable = isSpeakerOn())
             }
-            binding.ivBg.visibility = View.VISIBLE
         }
     }
 
@@ -620,12 +544,7 @@ open class P2PCallActivity : CommonCallActivity() {
     private inner class VideoRender : UIRender() {
         override fun renderForCaller() {
             super.renderForCaller()
-            forUserInfoUI(NECallType.VIDEO, callParam.calledAccId, forVideoCaller = true)
             doConfigSpeakerSwitch(speakerEnable = true)
-
-            binding.videoViewBig.visibility = View.GONE
-            binding.videoViewPreview.visibility = View.VISIBLE
-            binding.videoViewSmall.visibility = View.GONE
 
             binding.llOnTheCallOperation.visibility = View.GONE
             binding.calledOperationGroup.visibility = View.GONE
@@ -636,7 +555,6 @@ open class P2PCallActivity : CommonCallActivity() {
             binding.ivCallSwitchType.setImageResource(R.drawable.icon_call_tip_video_to_audio)
             binding.tvCallSwitchTypeDesc.setText(R.string.tip_switch_to_audio)
 
-            setupLocalView(binding.videoViewPreview)
             if (startPreviewCode != NERtcConstants.ErrorCode.OK &&
                 startPreviewCode != ENGINE_ERROR_DEVICE_PREVIEW_ALREADY_STARTED
             ) {
@@ -644,23 +562,14 @@ open class P2PCallActivity : CommonCallActivity() {
                     CallUILog.d(tag, "renderForCaller startPreviewCode is $this.")
                 }
             }
-            binding.ivBg.visibility = View.GONE
         }
 
         override fun renderForCalled() {
             super.renderForCalled()
-
-            forUserInfoUI(NECallType.VIDEO, NIMClient.getCurrentAccount())
-
-            binding.videoViewPreview.visibility = View.GONE
-            binding.videoViewBig.visibility = View.GONE
-            binding.videoViewSmall.visibility = View.GONE
-
             binding.llOnTheCallOperation.visibility = View.GONE
             binding.calledOperationGroup.visibility = View.VISIBLE
             binding.callerOperationGroup.visibility = View.GONE
             binding.callerAudioOperationGroup.visibility = View.GONE
-            binding.tvOtherCallTip.setText(R.string.tip_invite_to_video_call)
             binding.tvSwitchTypeDesc.setText(R.string.tip_switch_to_audio)
 
             binding.ivAccept.setImageResource(R.drawable.call_accept)
@@ -669,28 +578,15 @@ open class P2PCallActivity : CommonCallActivity() {
             binding.ivAccept.setOnClickListener(onClickListener)
             binding.ivReject.setOnClickListener(onClickListener)
             binding.ivSwitchType.setOnClickListener(onClickListener)
-
-            binding.ivBg.visibility = View.VISIBLE
         }
 
         override fun renderForOnTheCall(userAccId: String?) {
             super.renderForOnTheCall(userAccId)
-
-            forUserInfoUI(type = NECallType.VIDEO, visible = false)
-
-            binding.tvConnectingTip.visibility = View.GONE
-            binding.videoViewPreview.visibility = View.GONE
-            binding.videoViewSmall.visibility = View.VISIBLE
-            binding.videoViewBig.visibility = View.VISIBLE
-            binding.ivSmallVideoShade.visibility = View.GONE
-
             binding.calledOperationGroup.visibility = View.GONE
             binding.callerOperationGroup.visibility = View.GONE
             binding.callerAudioOperationGroup.visibility = View.GONE
             binding.llOnTheCallOperation.visibility = View.VISIBLE
-            binding.tvCountdown.visibility = View.VISIBLE
 
-            binding.videoViewSmall.setOnClickListener(onClickListener)
             binding.ivCallChannelTypeChange.setOnClickListener(onClickListener)
             binding.ivCallChannelTypeChange.setImageResource(R.drawable.video_to_audio)
             binding.ivMuteAudio.setOnClickListener(onClickListener)
@@ -699,208 +595,21 @@ open class P2PCallActivity : CommonCallActivity() {
             binding.ivHangUp.setOnClickListener(onClickListener)
             binding.ivMuteSpeaker.setOnClickListener(onClickListener)
             resetSwitchState(NECallType.VIDEO)
-            binding.ivBg.visibility = View.GONE
 
             firstLaunch = false
             binding.ivSwitchCamera.run {
                 visibility = View.VISIBLE
                 setOnClickListener(onClickListener)
             }
-            if (callParam.currentUserIsCaller()) {
-                NERtcEx.getInstance().setupLocalVideoCanvas(null)
-                NERtcEx.getInstance().stopVideoPreview()
-            }
-            setupRemoteView(binding.videoViewBig)
-            binding.videoViewPreview.release()
-            setupLocalView(binding.videoViewSmall)
         }
-
-        override fun updateOnTheCallState(state: UserState) {
-            super.updateOnTheCallState(state)
-            if (localIsSmallVideo) {
-                if (TextUtils.equals(state.userAccId, callParam.currentAccId)) {
-                    state.muteVideo?.run {
-                        loadImg(uiConfig?.closeVideoLocalUrl, binding.ivSmallVideoShade)
-                        binding.ivSmallVideoShade.visibility = if (this) View.VISIBLE else View.GONE
-                    }
-                } else {
-                    state.muteVideo?.run {
-                        loadImg(uiConfig?.closeVideoRemoteUrl, binding.ivBigVideoShade)
-                        binding.ivBigVideoShade.visibility = if (this) View.VISIBLE else View.GONE
-                        binding.tvRemoteVideoCloseTip.text =
-                            if (TextUtils.isEmpty(uiConfig?.closeVideoRemoteTip?.trim())) {
-                                getString(
-                                    R.string.ui_tip_close_camera_by_other
-                                )
-                            } else {
-                                uiConfig?.closeVideoRemoteTip
-                            }
-                        binding.tvRemoteVideoCloseTip.visibility = if (this) View.VISIBLE else View.GONE
-                    }
-                }
-            } else {
-                if (TextUtils.equals(state.userAccId, callParam.currentAccId)) {
-                    state.muteVideo?.run {
-                        loadImg(uiConfig?.closeVideoLocalUrl, binding.ivBigVideoShade)
-                        binding.ivBigVideoShade.visibility = if (this) View.VISIBLE else View.GONE
-                        binding.tvRemoteVideoCloseTip.text = if (TextUtils.isEmpty(
-                                uiConfig?.closeVideoLocalTip?.trim()
-                            )
-                        ) {
-                            getString(
-                                R.string.ui_tip_close_camera_by_self
-                            )
-                        } else {
-                            uiConfig?.closeVideoLocalTip
-                        }
-                        binding.tvRemoteVideoCloseTip.visibility = if (this) View.VISIBLE else View.GONE
-                    }
-                } else {
-                    state.muteVideo?.run {
-                        loadImg(uiConfig?.closeVideoRemoteUrl, binding.ivSmallVideoShade)
-                        binding.ivSmallVideoShade.visibility = if (this) View.VISIBLE else View.GONE
-                    }
-                }
-            }
-        }
-    }
-
-    private fun forUserInfoUI(
-        type: Int,
-        accId: String? = null,
-        visible: Boolean = true,
-        forVideoCaller: Boolean = false
-    ) {
-        if (!visible) {
-            binding.userInfoGroup.visibility = View.GONE
-            return
-        }
-        binding.userInfoGroup.visibility = View.VISIBLE
-
-        accId?.run {
-            fetchNickname {
-                binding.tvUserName.text = it
-            }
-            loadAvatarByAccId(
-                this@P2PCallActivity,
-                binding.ivUserInnerAvatar,
-                binding.ivBg,
-                binding.tvUserInnerAvatar,
-                uiConfig?.enableTextDefaultAvatar ?: true
-            )
-        }
-        val centerSize = 97.dip2Px(this)
-        val topSize = 60.dip2Px(this)
-
-        val constraintSet = ConstraintSet()
-        constraintSet.clone(binding.clRoot)
-        constraintSet.clear(R.id.flUserAvatar)
-        constraintSet.clear(R.id.tvOtherCallTip)
-        constraintSet.clear(R.id.tvUserName)
-        constraintSet.constrainHeight(R.id.tvOtherCallTip, ConstraintSet.WRAP_CONTENT)
-        constraintSet.constrainWidth(R.id.tvOtherCallTip, ConstraintSet.WRAP_CONTENT)
-        constraintSet.constrainWidth(R.id.tvUserName, ConstraintSet.WRAP_CONTENT)
-        constraintSet.constrainWidth(R.id.tvUserName, ConstraintSet.WRAP_CONTENT)
-
-        if (type == NECallType.VIDEO && forVideoCaller) {
-            val marginSize16 = 16.dip2Px(this)
-            binding.flUserAvatar.run {
-                constraintSet.constrainWidth(id, topSize)
-                constraintSet.constrainHeight(id, topSize)
-                constraintSet.connect(
-                    id,
-                    ConstraintSet.END,
-                    ConstraintSet.PARENT_ID,
-                    ConstraintSet.END,
-                    marginSize16
-                )
-                constraintSet.connect(
-                    id,
-                    ConstraintSet.TOP,
-                    ConstraintSet.PARENT_ID,
-                    ConstraintSet.TOP,
-                    marginSize16
-                )
-            }
-            val marginSize10 = 10.dip2Px(this)
-            val marginSize5 = 5.dip2Px(this)
-            binding.tvUserName.run {
-                textSize = 18f
-                constraintSet.connect(
-                    id,
-                    ConstraintSet.END,
-                    binding.flUserAvatar.id,
-                    ConstraintSet.START,
-                    marginSize10
-                )
-                constraintSet.connect(
-                    id,
-                    ConstraintSet.TOP,
-                    binding.flUserAvatar.id,
-                    ConstraintSet.TOP,
-                    marginSize5
-                )
-            }
-            binding.tvOtherCallTip.run {
-                setTextColor(ContextCompat.getColor(context, R.color.white))
-                constraintSet.connect(
-                    id,
-                    ConstraintSet.TOP,
-                    binding.tvUserName.id,
-                    ConstraintSet.BOTTOM,
-                    marginSize5
-                )
-                constraintSet.connect(
-                    id,
-                    ConstraintSet.END,
-                    binding.flUserAvatar.id,
-                    ConstraintSet.START,
-                    marginSize10
-                )
-            }
-        } else {
-            binding.flUserAvatar.run {
-                constraintSet.constrainWidth(id, centerSize)
-                constraintSet.constrainHeight(id, centerSize)
-                constraintSet.connect(
-                    id,
-                    ConstraintSet.TOP,
-                    ConstraintSet.PARENT_ID,
-                    ConstraintSet.TOP,
-                    160.dip2Px(context)
-                )
-                constraintSet.centerHorizontally(id, ConstraintSet.PARENT_ID)
-            }
-            binding.tvUserName.run {
-                textSize = 20f
-                constraintSet.centerHorizontally(id, ConstraintSet.PARENT_ID)
-                constraintSet.connect(
-                    id,
-                    ConstraintSet.TOP,
-                    binding.flUserAvatar.id,
-                    ConstraintSet.BOTTOM,
-                    15.dip2Px(context)
-                )
-            }
-            binding.tvOtherCallTip.run {
-                setTextColor(ContextCompat.getColor(context, R.color.color_cccccc))
-                constraintSet.connect(
-                    id,
-                    ConstraintSet.TOP,
-                    binding.tvUserName.id,
-                    ConstraintSet.BOTTOM,
-                    8.dip2Px(context)
-                )
-                constraintSet.centerHorizontally(id, ConstraintSet.PARENT_ID)
-            }
-        }
-        constraintSet.applyTo(binding.clRoot)
     }
 
     private fun resetSwitchState(callType: Int) {
         if (callType == NECallType.VIDEO) {
             doConfigSpeaker(true)
             binding.ivMuteSpeaker.setImageResource(R.drawable.speaker_on)
+            // 使用 SingleVideoCallLayout 重置切换状态
+            p2PVideoCallLayout.resetSwitchState(callType)
         } else {
             doConfigSpeaker(false)
             binding.ivMuteSpeaker.setImageResource(R.drawable.speaker_off)
@@ -909,9 +618,9 @@ open class P2PCallActivity : CommonCallActivity() {
         localIsSmallVideo = true
 
         doMuteAudio(false)
-        binding.ivMuteVideo.setImageResource(R.drawable.cam_on)
-        binding.tvRemoteVideoCloseTip.visibility = View.GONE
-        binding.videoViewSmall.setBackgroundColor(Color.TRANSPARENT)
+        if (callType == NECallType.VIDEO) {
+            binding.ivMuteVideo.setImageResource(R.drawable.cam_on)
+        }
         // 音频
         if (isLocalMuteAudio) {
             doMuteAudioSwitch(binding.ivMuteAudio)
@@ -925,9 +634,4 @@ open class P2PCallActivity : CommonCallActivity() {
             .centerCrop()
             .into(imageView)
     }
-
-    class UserState(
-        val userAccId: String?,
-        val muteVideo: Boolean? = null
-    )
 }

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/fragment/onthecall/AudioOnTheCallFragment.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/fragment/onthecall/AudioOnTheCallFragment.kt
@@ -25,7 +25,6 @@ import com.netease.yunxin.nertc.ui.base.loadAvatarByAccId
 import com.netease.yunxin.nertc.ui.databinding.FragmentP2pAudioOnTheCallBinding
 import com.netease.yunxin.nertc.ui.p2p.CallUIOperationsMgr
 import com.netease.yunxin.nertc.ui.p2p.P2PUIConfig
-import com.netease.yunxin.nertc.ui.p2p.fragment.BaseP2pCallFragment
 import com.netease.yunxin.nertc.ui.p2p.fragment.P2PUIUpdateType.CHANGE_CALL_TYPE
 import com.netease.yunxin.nertc.ui.p2p.fragment.P2PUIUpdateType.FROM_FLOATING_WINDOW
 import com.netease.yunxin.nertc.ui.p2p.fragment.P2PUIUpdateType.INIT
@@ -38,7 +37,7 @@ import kotlinx.coroutines.launch
 /**
  * 音频通话页面
  */
-open class AudioOnTheCallFragment : BaseP2pCallFragment() {
+open class AudioOnTheCallFragment : BaseOnTheCallFragment() {
 
     protected val logTag = "AudioOnTheCallFragment"
 
@@ -170,9 +169,14 @@ open class AudioOnTheCallFragment : BaseP2pCallFragment() {
     }
 
     override fun onCreateAction() {
+        super.onCreateAction()
         if (bridge.currentCallState() == CallState.STATE_IDLE) {
             bridge.doCall()
         }
+    }
+
+    override fun onDestroyAction() {
+        super.onDestroyAction()
     }
 
     override fun onCallEnd(info: NECallEndInfo) {

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/fragment/onthecall/BaseOnTheCallFragment.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/fragment/onthecall/BaseOnTheCallFragment.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.p2p.fragment.onthecall
+
+import com.netease.yunxin.nertc.ui.p2p.fragment.BaseP2pCallFragment
+
+open class BaseOnTheCallFragment : BaseP2pCallFragment() {
+
+    override fun onCreateAction() {
+        super.onCreateAction()
+
+        // 开启AI字幕功能
+//        val config = NERtcASRCaptionConfig()
+//        config.dstLanguageArr = arrayOf("en") // 指定字幕的目标语言，zh表示简体中文
+//        NERtcEx.getInstance().startASRCaption(config)
+    }
+
+    override fun onDestroyAction() {
+        super.onDestroyAction()
+        // 关闭AI字幕功能
+//        NERtcEx.getInstance().stopASRCaption()
+    }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/fragment/onthecall/VideoOnTheCallFragment.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/p2p/fragment/onthecall/VideoOnTheCallFragment.kt
@@ -40,7 +40,6 @@ import com.netease.yunxin.nertc.ui.floating.FloatingWindowWrapper
 import com.netease.yunxin.nertc.ui.p2p.ActivityFloatingView
 import com.netease.yunxin.nertc.ui.p2p.CallUIOperationsMgr
 import com.netease.yunxin.nertc.ui.p2p.P2PUIConfig
-import com.netease.yunxin.nertc.ui.p2p.fragment.BaseP2pCallFragment
 import com.netease.yunxin.nertc.ui.p2p.fragment.P2PUIUpdateType.CHANGE_CALL_TYPE
 import com.netease.yunxin.nertc.ui.p2p.fragment.P2PUIUpdateType.FROM_FLOATING_WINDOW
 import com.netease.yunxin.nertc.ui.p2p.fragment.P2PUIUpdateType.INIT
@@ -54,7 +53,7 @@ import kotlinx.coroutines.launch
 /**
  * 视频通话页面
  */
-open class VideoOnTheCallFragment : BaseP2pCallFragment() {
+open class VideoOnTheCallFragment : BaseOnTheCallFragment() {
 
     protected val logTag = "VideoOnTheCallFragment"
 
@@ -252,6 +251,7 @@ open class VideoOnTheCallFragment : BaseP2pCallFragment() {
     }
 
     override fun onCreateAction() {
+        super.onCreateAction()
         NERtcCallbackProxyMgr.getInstance().addCallback(rtcCallback)
         if (bridge.currentCallState() == CallState.STATE_IDLE) {
             bridge.doCall()

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/permission/PermissionActivity.java
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/permission/PermissionActivity.java
@@ -1,0 +1,219 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.nertc.ui.permission;
+
+import android.annotation.SuppressLint;
+import android.app.ActionBar;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.drawable.ColorDrawable;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.ImageView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.netease.yunxin.nertc.ui.R;
+import com.netease.yunxin.nertc.ui.event.EventManager;
+import com.netease.yunxin.nertc.ui.utils.CallUILog;
+import com.netease.yunxin.nertc.ui.utils.DeviceUtils;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PermissionActivity extends Activity {
+  private static final String TAG = "PermissionActivity";
+  private static final int PERMISSION_REQUEST_CODE = 100;
+  private TextView mRationaleTitleTv;
+  private TextView mRationaleDescriptionTv;
+  private ImageView mPermissionIconIv;
+  private PermissionRequester.RequestData mRequestData;
+  private PermissionRequester.Result mResult;
+
+  public PermissionActivity() {
+    this.mResult = PermissionRequester.Result.Denied;
+  }
+
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    this.mRequestData = this.getPermissionRequest();
+    if (this.mRequestData != null && !this.mRequestData.isPermissionsExistEmpty()) {
+      CallUILog.i(TAG, "onCreate : " + this.mRequestData.toString());
+      if (DeviceUtils.getVersionInt() < 23) {
+        this.finishWithResult(PermissionRequester.Result.Granted);
+      } else {
+        this.makeBackGroundTransparent();
+        this.initView();
+        this.showPermissionRationale();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+          this.requestPermissions(this.mRequestData.getPermissions(), PERMISSION_REQUEST_CODE);
+        } else {
+          CallUILog.i(TAG, "onCreate : " + this.mRequestData.toString());
+        }
+      }
+    } else {
+      CallUILog.e(TAG, "onCreate mRequestData exist empty permission");
+      this.finishWithResult(PermissionRequester.Result.Denied);
+    }
+  }
+
+  public void onRequestPermissionsResult(
+      int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    this.hidePermissionRationale();
+    if (this.isAllPermissionsGranted(grantResults)) {
+      this.finishWithResult(PermissionRequester.Result.Granted);
+    } else {
+      this.showSettingsTip();
+    }
+  }
+
+  private void showSettingsTip() {
+    if (this.mRequestData != null) {
+      View tipLayout =
+          LayoutInflater.from(this).inflate(R.layout.view_permission_tip_layout, (ViewGroup) null);
+      TextView tipsTv = (TextView) tipLayout.findViewById(R.id.tips);
+      TextView positiveBtn = (TextView) tipLayout.findViewById(R.id.positive_btn);
+      TextView negativeBtn = (TextView) tipLayout.findViewById(R.id.negative_btn);
+      tipsTv.setText(this.mRequestData.getSettingsTip());
+      Dialog permissionTipDialog =
+          (new AlertDialog.Builder(this)).setView(tipLayout).setCancelable(false).create();
+      positiveBtn.setOnClickListener(
+          (v) -> {
+            permissionTipDialog.dismiss();
+            this.launchAppDetailsSettings();
+            this.finishWithResult(PermissionRequester.Result.Requesting);
+          });
+      negativeBtn.setOnClickListener(
+          (v) -> {
+            permissionTipDialog.dismiss();
+            this.finishWithResult(PermissionRequester.Result.Denied);
+          });
+      ((Dialog) permissionTipDialog)
+          .setOnKeyListener(
+              (dialog, keyCode, event) -> {
+                if (keyCode == 4 && event.getAction() == 1) {
+                  permissionTipDialog.dismiss();
+                }
+
+                return true;
+              });
+      Window dialogWindow = ((Dialog) permissionTipDialog).getWindow();
+      dialogWindow.setBackgroundDrawable(new ColorDrawable());
+      WindowManager.LayoutParams layoutParams = dialogWindow.getAttributes();
+      layoutParams.width = -2;
+      layoutParams.height = -2;
+      dialogWindow.setAttributes(layoutParams);
+      ((Dialog) permissionTipDialog).show();
+    }
+  }
+
+  private void launchAppDetailsSettings() {
+    Intent intent = new Intent("android.settings.APPLICATION_DETAILS_SETTINGS");
+    intent.setData(Uri.parse("package:" + this.getPackageName()));
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    if (this.getPackageManager()
+            .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+            .size()
+        <= 0) {
+      CallUILog.e(TAG, "launchAppDetailsSettings can not find system settings");
+    } else {
+      this.startActivity(intent);
+    }
+  }
+
+  private void finishWithResult(PermissionRequester.Result result) {
+    CallUILog.i(TAG, "finishWithResult : " + result);
+    this.mResult = result;
+    this.finish();
+  }
+
+  protected void onDestroy() {
+    super.onDestroy();
+    Map<String, Object> result = new HashMap(1);
+    result.put("PERMISSION_RESULT", this.mResult);
+    EventManager.getInstance()
+        .notifyEvent("PERMISSION_NOTIFY_EVENT_KEY", "PERMISSION_NOTIFY_EVENT_SUB_KEY", result);
+  }
+
+  private PermissionRequester.RequestData getPermissionRequest() {
+    Intent intent = this.getIntent();
+    return intent == null
+        ? null
+        : (PermissionRequester.RequestData) intent.getParcelableExtra("PERMISSION_REQUEST_KEY");
+  }
+
+  @SuppressLint({"NewApi"})
+  private void makeBackGroundTransparent() {
+    if (DeviceUtils.getVersionInt() >= 21) {
+      View decorView = this.getWindow().getDecorView();
+      decorView.setSystemUiVisibility(
+          View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+              | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+              | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+              | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+              | View.SYSTEM_UI_FLAG_FULLSCREEN
+              | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+      this.getWindow().setStatusBarColor(0);
+      this.getWindow().setNavigationBarColor(0);
+    }
+
+    ActionBar actionBar = this.getActionBar();
+    if (actionBar != null) {
+      actionBar.hide();
+    }
+  }
+
+  private void initView() {
+    this.setContentView(R.layout.activity_permission_layout);
+    this.mRationaleTitleTv = (TextView) this.findViewById(R.id.permission_reason_title);
+    this.mRationaleDescriptionTv = (TextView) this.findViewById(R.id.permission_reason);
+    this.mPermissionIconIv = (ImageView) this.findViewById(R.id.permission_icon);
+  }
+
+  private void showPermissionRationale() {
+    if (this.mRequestData != null) {
+      this.mRationaleTitleTv.setText(this.mRequestData.getTitle());
+      this.mRationaleDescriptionTv.setText(this.mRequestData.getDescription());
+      this.mPermissionIconIv.setBackgroundResource(this.mRequestData.getPermissionIconId());
+      this.mRationaleTitleTv.setVisibility(View.VISIBLE);
+      this.mRationaleDescriptionTv.setVisibility(View.VISIBLE);
+      this.mPermissionIconIv.setVisibility(View.VISIBLE);
+    }
+  }
+
+  private void hidePermissionRationale() {
+    this.mRationaleTitleTv.setVisibility(View.GONE);
+    this.mRationaleDescriptionTv.setVisibility(View.GONE);
+    this.mPermissionIconIv.setVisibility(View.GONE);
+  }
+
+  private boolean isAllPermissionsGranted(@NonNull int[] grantResults) {
+    int[] var2 = grantResults;
+    int var3 = grantResults.length;
+
+    for (int var4 = 0; var4 < var3; ++var4) {
+      int result = var2[var4];
+      if (result != 0) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public boolean onTouchEvent(MotionEvent event) {
+    return true;
+  }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/permission/PermissionCallback.java
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/permission/PermissionCallback.java
@@ -1,0 +1,15 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.nertc.ui.permission;
+
+public abstract class PermissionCallback {
+  public PermissionCallback() {}
+
+  public abstract void onGranted();
+
+  public void onRequesting() {}
+
+  public void onDenied() {}
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/permission/PermissionRequest.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/permission/PermissionRequest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.permission
+
+import android.Manifest
+import android.content.Context
+import com.netease.yunxin.kit.call.p2p.model.NECallType
+import com.netease.yunxin.nertc.ui.R
+
+object PermissionRequest {
+    fun requestPermissions(context: Context, type: Int, callback: PermissionCallback?) {
+        val title = StringBuilder().append(context.getString(R.string.ui_permission_microphone))
+        val reason = StringBuilder()
+        reason.append(getMicrophonePermissionHint(context))
+
+        val permissionList: MutableList<String> = ArrayList()
+        permissionList.add(Manifest.permission.RECORD_AUDIO)
+        if (NECallType.VIDEO == type) {
+            title.append(context.getString(R.string.ui_permission_separator))
+            title.append(context.getString(R.string.ui_permission_camera))
+            reason.append(getCameraPermissionHint(context))
+            permissionList.add(Manifest.permission.CAMERA)
+        }
+
+        if (PermissionRequester.newInstance(*permissionList.toTypedArray()).has()) {
+            callback?.onGranted()
+            return
+        }
+
+        val permissionCallback: PermissionCallback = object : PermissionCallback() {
+            override fun onGranted() {
+                callback?.onGranted()
+            }
+
+            override fun onDenied() {
+                super.onDenied()
+                callback?.onDenied()
+            }
+        }
+        val applicationInfo = context.applicationInfo
+        val appName = context.packageManager.getApplicationLabel(applicationInfo).toString()
+        PermissionRequester.newInstance(*permissionList.toTypedArray())
+            .title(context.getString(R.string.ui_permission_title, appName, title))
+            .description(reason.toString())
+            .settingsTip(
+                "${context.getString(R.string.ui_permission_tips, title)} $reason".trimIndent()
+            )
+            .callback(permissionCallback)
+            .request()
+    }
+
+    fun requestCameraPermission(context: Context, callback: PermissionCallback?) {
+        if (PermissionRequester.newInstance(Manifest.permission.CAMERA).has()) {
+            callback?.onGranted()
+            return
+        }
+
+        val permissionCallback: PermissionCallback = object : PermissionCallback() {
+            override fun onGranted() {
+                callback?.onGranted()
+            }
+
+            override fun onDenied() {
+                super.onDenied()
+                callback?.onDenied()
+            }
+        }
+
+        val title = context.getString(R.string.ui_permission_camera)
+        val reason = getCameraPermissionHint(context)
+        val appName = context.packageManager.getApplicationLabel(context.applicationInfo).toString()
+
+        PermissionRequester.newInstance(Manifest.permission.CAMERA)
+            .title(context.getString(R.string.ui_permission_title, appName, title))
+            .description(reason)
+            .settingsTip(
+                "${context.getString(R.string.ui_permission_tips, title)} $reason".trimIndent()
+            )
+            .callback(permissionCallback)
+            .request()
+    }
+
+    private fun getMicrophonePermissionHint(context: Context): String {
+        return context.getString(R.string.ui_permission_mic_reason)
+    }
+
+    private fun getCameraPermissionHint(context: Context): String {
+        return context.getString(R.string.ui_permission_camera_reason)
+    }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/permission/PermissionRequester.java
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/permission/PermissionRequester.java
@@ -1,0 +1,606 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.nertc.ui.permission;
+
+import android.annotation.SuppressLint;
+import android.app.AppOpsManager;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Binder;
+import android.os.Build.VERSION;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.os.Process;
+import android.provider.Settings;
+import android.text.TextUtils;
+import android.widget.Toast;
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.annotation.Size;
+import androidx.core.content.ContextCompat;
+import com.netease.yunxin.kit.corekit.XKit;
+import com.netease.yunxin.nertc.ui.R;
+import com.netease.yunxin.nertc.ui.event.EventManager;
+import com.netease.yunxin.nertc.ui.utils.CallUILog;
+import com.netease.yunxin.nertc.ui.utils.DeviceUtils;
+import java.lang.String;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class PermissionRequester {
+  private static final String TAG = "PermissionRequester";
+  public static final String PERMISSION_NOTIFY_EVENT_KEY = "PERMISSION_NOTIFY_EVENT_KEY";
+  public static final String PERMISSION_NOTIFY_EVENT_SUB_KEY = "PERMISSION_NOTIFY_EVENT_SUB_KEY";
+  public static final String PERMISSION_RESULT = "PERMISSION_RESULT";
+  public static final String PERMISSION_REQUEST_KEY = "PERMISSION_REQUEST_KEY";
+  private static final Object sLock = new Object();
+  private static AtomicBoolean sIsRequesting = new AtomicBoolean(false);
+  private PermissionCallback mPermissionCallback;
+  private String[] mPermissions;
+  private String mTitle;
+  private String mDescription;
+  private String mSettingsTip;
+  private EventManager.INotifyEvent mPermissionNotification;
+  public static final String FLOAT_PERMISSION = "PermissionOverlayWindows";
+  public static final String BG_START_PERMISSION = "PermissionStartActivityFromBackground";
+  private List<String> mDirectPermissionList = new ArrayList();
+  private List<String> mIndirectPermissionList = new ArrayList();
+
+  private PermissionRequester(String... permissions) {
+    this.mPermissions = permissions;
+    String[] var2 = this.mPermissions;
+    int var3 = var2.length;
+
+    for (int var4 = 0; var4 < var3; ++var4) {
+      String permission = var2[var4];
+      if (!"PermissionOverlayWindows".equals(permission)
+          && !"PermissionStartActivityFromBackground".equals(permission)) {
+        this.mDirectPermissionList.add(permission);
+      } else {
+        this.mIndirectPermissionList.add(permission);
+      }
+    }
+
+    this.mPermissionNotification =
+        (key, subKey, param) -> {
+          if (param != null) {
+            Object result = param.get("PERMISSION_RESULT");
+            if (result != null) {
+              this.notifyPermissionRequestResult((Result) result);
+            }
+          }
+        };
+  }
+
+  public static PermissionRequester newInstance(@NonNull @Size(min = 1L) String... permissions) {
+    return new PermissionRequester(permissions);
+  }
+
+  public PermissionRequester title(@NonNull String title) {
+    this.mTitle = title;
+    return this;
+  }
+
+  public PermissionRequester description(@NonNull String description) {
+    this.mDescription = description;
+    return this;
+  }
+
+  public PermissionRequester settingsTip(@NonNull String settingsTip) {
+    this.mSettingsTip = settingsTip;
+    return this;
+  }
+
+  public PermissionRequester callback(@NonNull PermissionCallback callback) {
+    this.mPermissionCallback = callback;
+    return this;
+  }
+
+  @SuppressLint({"NewApi"})
+  public void request() {
+    CallUILog.i(
+        "PermissionRequester",
+        "request, directPermissionList: "
+            + this.mDirectPermissionList
+            + " ,indirectPermissionList:  "
+            + this.mIndirectPermissionList);
+    if (this.mDirectPermissionList != null && this.mDirectPermissionList.size() > 0) {
+      this.requestDirectPermission((String[]) this.mDirectPermissionList.toArray(new String[0]));
+    }
+
+    if (this.mIndirectPermissionList != null && this.mIndirectPermissionList.size() > 0) {
+      this.startAppDetailsSettingsByBrand();
+    }
+  }
+
+  @SuppressLint({"NewApi"})
+  private void requestDirectPermission(String[] permissions) {
+    synchronized (sLock) {
+      if (sIsRequesting.get()) {
+        CallUILog.e("PermissionRequester", "can not request during requesting");
+        if (this.mPermissionCallback != null) {
+          this.mPermissionCallback.onDenied();
+        }
+
+        return;
+      }
+
+      sIsRequesting.set(true);
+    }
+
+    EventManager.getInstance()
+        .registerEvent(
+            "PERMISSION_NOTIFY_EVENT_KEY",
+            "PERMISSION_NOTIFY_EVENT_SUB_KEY",
+            this.mPermissionNotification);
+    if (VERSION.SDK_INT < 23) {
+      CallUILog.i("PermissionRequester", "current version is lower than 23");
+      this.notifyPermissionRequestResult(Result.Granted);
+    } else {
+      String[] unauthorizedPermissions = this.findUnauthorizedPermissions(permissions);
+      if (unauthorizedPermissions.length <= 0) {
+        this.notifyPermissionRequestResult(Result.Granted);
+      } else {
+        RequestData realRequest =
+            new RequestData(
+                this.mTitle, this.mDescription, this.mSettingsTip, unauthorizedPermissions);
+        this.startPermissionActivity(realRequest);
+      }
+    }
+  }
+
+  public boolean has() {
+    if (!this.mIndirectPermissionList.contains("PermissionStartActivityFromBackground")) {
+      if (this.mIndirectPermissionList.contains("PermissionOverlayWindows")) {
+        return this.hasFloatPermission();
+      } else {
+        Iterator var1 = this.mDirectPermissionList.iterator();
+
+        String permission;
+        do {
+          if (!var1.hasNext()) {
+            return true;
+          }
+
+          permission = (String) var1.next();
+        } while (this.has(permission));
+
+        return false;
+      }
+    } else {
+      return this.hasFloatPermission() && this.hasBgStartPermission();
+    }
+  }
+
+  private boolean has(final String permission) {
+    return VERSION.SDK_INT < 23
+        || 0
+            == ContextCompat.checkSelfPermission(
+                XKit.Companion.instance().getApplicationContext(), permission);
+  }
+
+  private void notifyPermissionRequestResult(Result result) {
+    EventManager.getInstance()
+        .unRegisterEvent(
+            "PERMISSION_NOTIFY_EVENT_KEY",
+            "PERMISSION_NOTIFY_EVENT_SUB_KEY",
+            this.mPermissionNotification);
+    sIsRequesting.set(false);
+    if (this.mPermissionCallback != null) {
+      if (Result.Granted.equals(result)) {
+        this.mPermissionCallback.onGranted();
+      } else if (Result.Requesting.equals(result)) {
+        this.mPermissionCallback.onRequesting();
+      } else {
+        this.mPermissionCallback.onDenied();
+      }
+
+      this.mPermissionCallback = null;
+    }
+  }
+
+  private String[] findUnauthorizedPermissions(String[] permissions) {
+    Context appContext = XKit.Companion.instance().getApplicationContext();
+    if (appContext == null) {
+      CallUILog.e("PermissionRequester", "findUnauthorizedPermissions appContext is null");
+      return permissions;
+    } else {
+      List<String> unauthorizedList = new LinkedList();
+      String[] var4 = permissions;
+      int var5 = permissions.length;
+
+      for (int var6 = 0; var6 < var5; ++var6) {
+        String permission = var4[var6];
+        if (0 != ContextCompat.checkSelfPermission(appContext, permission)) {
+          unauthorizedList.add(permission);
+        }
+      }
+
+      return (String[]) unauthorizedList.toArray(new String[0]);
+    }
+  }
+
+  @RequiresApi(api = 23)
+  private void startPermissionActivity(RequestData request) {
+    Context context = XKit.Companion.instance().getApplicationContext();
+    if (context != null) {
+      Intent intent = new Intent(context, PermissionActivity.class);
+      intent.putExtra("PERMISSION_REQUEST_KEY", request);
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      context.startActivity(intent);
+    }
+  }
+
+  private void startAppDetailsSettingsByBrand() {
+    if (DeviceUtils.isBrandVivo()) {
+      this.startVivoPermissionSettings(XKit.Companion.instance().getApplicationContext());
+    } else if (DeviceUtils.isBrandHuawei()) {
+      this.startHuaweiPermissionSettings(XKit.Companion.instance().getApplicationContext());
+    } else if (DeviceUtils.isBrandXiaoMi()) {
+      this.startXiaomiPermissionSettings(XKit.Companion.instance().getApplicationContext());
+    } else {
+      this.startCommonSettings(XKit.Companion.instance().getApplicationContext());
+    }
+  }
+
+  private void startCommonSettings(Context context) {
+    try {
+      if (VERSION.SDK_INT >= 23) {
+        Intent intent = new Intent("android.settings.action.MANAGE_OVERLAY_PERMISSION");
+        intent.setData(Uri.parse("package:" + context.getPackageName()));
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+      }
+    } catch (Exception var3) {
+      Exception e = var3;
+      e.printStackTrace();
+    }
+  }
+
+  private void startVivoPermissionSettings(Context context) {
+    try {
+      Intent intent = new Intent();
+      intent.setClassName(
+          "com.vivo.permissionmanager",
+          "com.vivo.permissionmanager.activity.SoftPermissionDetailActivity");
+      intent.setAction("secure.intent.action.softPermissionDetail");
+      intent.putExtra("packagename", context.getPackageName());
+      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      context.startActivity(intent);
+      Toast.makeText(context, R.string.ui_float_permission_hint, Toast.LENGTH_SHORT).show();
+    } catch (Exception var3) {
+      CallUILog.w("PermissionRequester", "startVivoPermissionSettings: open common settings");
+      this.startCommonSettings(context);
+    }
+  }
+
+  private void startHuaweiPermissionSettings(Context context) {
+    if (!DeviceUtils.isHarmonyOS()) {
+      CallUILog.i("PermissionRequester", "The device is not Harmony or cannot get system operator");
+      this.startCommonSettings(context);
+    } else {
+      try {
+        Intent intent = new Intent();
+        intent.putExtra("packageName", context.getPackageName());
+        ComponentName comp =
+            new ComponentName(
+                "com.huawei.systemmanager", "com.huawei.permissionmanager.ui.MainActivity");
+        intent.setComponent(comp);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+        Toast.makeText(context, R.string.ui_float_permission_hint_harmony, Toast.LENGTH_SHORT)
+            .show();
+      } catch (Exception var4) {
+        CallUILog.w("PermissionRequester", "startHuaweiPermissionSettings: open common settings");
+        this.startCommonSettings(context);
+      }
+    }
+  }
+
+  private void startXiaomiPermissionSettings(Context context) {
+    if (!DeviceUtils.isMiuiOptimization()) {
+      CallUILog.i(
+          "PermissionRequester",
+          "The device do not open miuiOptimization or cannot get miui property");
+      this.startCommonSettings(context);
+    } else {
+      try {
+        Intent intent = new Intent("miui.intent.action.APP_PERM_EDITOR");
+        intent.setClassName(
+            "com.miui.securitycenter", "com.miui.permcenter.permissions.PermissionsEditorActivity");
+        intent.putExtra("extra_pkgname", context.getPackageName());
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+        Toast.makeText(context, R.string.ui_float_permission_hint, Toast.LENGTH_SHORT).show();
+      } catch (Exception var3) {
+        CallUILog.w("PermissionRequester", "startXiaomiPermissionSettings: open common settings");
+        this.startCommonSettings(context);
+      }
+    }
+  }
+
+  private boolean hasBgStartPermission() {
+    if (DeviceUtils.isBrandHuawei() && DeviceUtils.isHarmonyOS()) {
+      return this.isHarmonyBgStartPermissionAllowed(
+          XKit.Companion.instance().getApplicationContext());
+    } else if (DeviceUtils.isBrandVivo()) {
+      return this.isVivoBgStartPermissionAllowed(XKit.Companion.instance().getApplicationContext());
+    } else {
+      return DeviceUtils.isBrandXiaoMi() && DeviceUtils.isMiuiOptimization()
+          ? this.isXiaomiBgStartPermissionAllowed(XKit.Companion.instance().getApplicationContext())
+          : this.hasFloatPermission();
+    }
+  }
+
+  private boolean hasFloatPermission() {
+    try {
+      Context context = XKit.Companion.instance().getApplicationContext();
+      if (VERSION.SDK_INT >= 23) {
+        return Settings.canDrawOverlays(context);
+      }
+
+      if (VERSION.SDK_INT >= 19) {
+        AppOpsManager manager = (AppOpsManager) context.getSystemService(Context.APP_OPS_SERVICE);
+        if (manager == null) {
+          return false;
+        }
+
+        Method method =
+            AppOpsManager.class.getMethod("checkOp", Integer.TYPE, Integer.TYPE, String.class);
+        int result =
+            (Integer) method.invoke(manager, 24, Binder.getCallingUid(), context.getPackageName());
+        CallUILog.i("PermissionRequester", "hasFloatPermission, result: " + (0 == result));
+        return 0 == result;
+      }
+    } catch (Exception var5) {
+      Exception e = var5;
+      e.printStackTrace();
+    }
+
+    return false;
+  }
+
+  private boolean isHarmonyBgStartPermissionAllowed(Context context) {
+    try {
+      if (VERSION.SDK_INT >= 19) {
+        AppOpsManager manager = (AppOpsManager) context.getSystemService(Context.APP_OPS_SERVICE);
+        if (manager == null) {
+          return false;
+        }
+
+        Class<?> clz = Class.forName("com.huawei.android.app.AppOpsManagerEx");
+        Method method =
+            clz.getDeclaredMethod(
+                "checkHwOpNoThrow", AppOpsManager.class, Integer.TYPE, Integer.TYPE, String.class);
+        int result =
+            (Integer)
+                method.invoke(
+                    clz.newInstance(), manager, 100000, Process.myUid(), context.getPackageName());
+        CallUILog.i(
+            "PermissionRequester", "isHarmonyBgStartPermissionAllowed, result: " + (result == 0));
+        return result == 0;
+      }
+    } catch (Exception var6) {
+      Exception e = var6;
+      e.printStackTrace();
+    }
+
+    return false;
+  }
+
+  private boolean isVivoBgStartPermissionAllowed(Context context) {
+    try {
+      Uri uri =
+          Uri.parse("content://com.vivo.permissionmanager.provider.permission/start_bg_activity");
+      Cursor cursor =
+          context
+              .getContentResolver()
+              .query(
+                  uri,
+                  (String[]) null,
+                  "pkgname = ?",
+                  new String[] {context.getPackageName()},
+                  (String) null);
+      if (cursor == null) {
+        return false;
+      }
+
+      if (cursor.moveToFirst()) {
+        int columnIndex = cursor.getColumnIndex("currentstate");
+        if (columnIndex >= 0) {
+          int result = cursor.getInt(columnIndex);
+          cursor.close();
+          CallUILog.i(
+              "PermissionRequester", "isVivoBgStartPermissionAllowed, result: " + (0 == result));
+          return 0 == result;
+        } else {
+          cursor.close();
+          CallUILog.w(
+              "PermissionRequester",
+              "isVivoBgStartPermissionAllowed, column 'currentstate' not found");
+          return false;
+        }
+      }
+
+      cursor.close();
+    } catch (Exception var5) {
+      Exception e = var5;
+      e.printStackTrace();
+    }
+
+    return false;
+  }
+
+  private boolean isXiaomiBgStartPermissionAllowed(Context context) {
+    try {
+      AppOpsManager appOpsManager = null;
+      if (VERSION.SDK_INT >= 19) {
+        appOpsManager = (AppOpsManager) context.getSystemService(Context.APP_OPS_SERVICE);
+      }
+
+      if (appOpsManager == null) {
+        return false;
+      } else {
+        int op = 10021;
+        Method method =
+            appOpsManager
+                .getClass()
+                .getMethod("checkOpNoThrow", Integer.TYPE, Integer.TYPE, String.class);
+        method.setAccessible(true);
+        int result =
+            (Integer)
+                method.invoke(
+                    appOpsManager, Integer.valueOf(op), Process.myUid(), context.getPackageName());
+        CallUILog.i(
+            "PermissionRequester", "isXiaomiBgStartPermissionAllowed, result: " + (0 == result));
+        return 0 == result;
+      }
+    } catch (Exception var6) {
+      Exception e = var6;
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  public static boolean isGranted(final String... permissions) {
+    String[] var1 = permissions;
+    int var2 = permissions.length;
+
+    for (int var3 = 0; var3 < var2; ++var3) {
+      String permission = var1[var3];
+      if (!isGranted(permission)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public static boolean isGranted(final String permission) {
+    return VERSION.SDK_INT < 23
+        || 0
+            == ContextCompat.checkSelfPermission(
+                XKit.Companion.instance().getApplicationContext(), permission);
+  }
+
+  static class RequestData implements Parcelable {
+    private final String[] mPermissions;
+    private final String mTitle;
+    private final String mDescription;
+    private final String mSettingsTip;
+    private int mPermissionIconId;
+    public static final Creator<RequestData> CREATOR =
+        new Creator<RequestData>() {
+          public RequestData createFromParcel(Parcel in) {
+            return new RequestData(in);
+          }
+
+          public RequestData[] newArray(int size) {
+            return new RequestData[size];
+          }
+        };
+
+    public RequestData(
+        @NonNull String title,
+        @NonNull String description,
+        @NonNull String settingsTip,
+        @NonNull String... perms) {
+      this.mTitle = title;
+      this.mDescription = description;
+      this.mSettingsTip = settingsTip;
+      this.mPermissions = perms.clone();
+    }
+
+    protected RequestData(Parcel in) {
+      this.mPermissions = in.createStringArray();
+      this.mTitle = in.readString();
+      this.mDescription = in.readString();
+      this.mSettingsTip = in.readString();
+      this.mPermissionIconId = in.readInt();
+    }
+
+    public boolean isPermissionsExistEmpty() {
+      if (this.mPermissions != null && this.mPermissions.length > 0) {
+        String[] var1 = this.mPermissions;
+        int var2 = var1.length;
+
+        for (int var3 = 0; var3 < var2; ++var3) {
+          String permission = var1[var3];
+          if (TextUtils.isEmpty(permission)) {
+            return true;
+          }
+        }
+
+        return false;
+      } else {
+        return true;
+      }
+    }
+
+    public String[] getPermissions() {
+      return (String[]) this.mPermissions.clone();
+    }
+
+    public String getTitle() {
+      return this.mTitle;
+    }
+
+    public String getDescription() {
+      return this.mDescription;
+    }
+
+    public String getSettingsTip() {
+      return this.mSettingsTip;
+    }
+
+    public int getPermissionIconId() {
+      return this.mPermissionIconId;
+    }
+
+    public void setPermissionIconId(int permissionIconId) {
+      this.mPermissionIconId = permissionIconId;
+    }
+
+    public String toString() {
+      return "PermissionRequest{mPermissions="
+          + Arrays.toString(this.mPermissions)
+          + ", mTitle="
+          + this.mTitle
+          + ", mDescription='"
+          + this.mDescription
+          + ", mSettingsTip='"
+          + this.mSettingsTip
+          + '}';
+    }
+
+    public int describeContents() {
+      return 0;
+    }
+
+    public void writeToParcel(Parcel dest, int flags) {
+      dest.writeStringArray(this.mPermissions);
+      dest.writeString(this.mTitle);
+      dest.writeString(this.mDescription);
+      dest.writeString(this.mSettingsTip);
+      dest.writeInt(this.mPermissionIconId);
+    }
+  }
+
+  public static enum Result {
+    Granted,
+    Denied,
+    Requesting;
+
+    private Result() {}
+  }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/service/foregroundservice/AudioForegroundService.java
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/service/foregroundservice/AudioForegroundService.java
@@ -1,0 +1,149 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.nertc.ui.service.foregroundservice;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.os.Build.VERSION;
+import android.os.IBinder;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+import com.netease.yunxin.kit.corekit.XKit;
+import com.netease.yunxin.nertc.ui.R;
+import com.netease.yunxin.nertc.ui.utils.CallUILog;
+
+public class AudioForegroundService extends Service {
+  private static final String TAG = "AudioForegroundService";
+  private static final String TITLE = "title";
+  private static final String ICON = "icon";
+  private static final String DESCRIPTION = "description";
+  private static final int NOTIFICATION_ID = 1001;
+  private static ServiceState state;
+
+  public static void start(Context context, String title, String description, int icon) {
+    if (state != ServiceState.STARTING && state != ServiceState.RUNNING) {
+      if (state == ServiceState.STOPPING) {
+        state = ServiceState.STARTING;
+        CallUILog.i(TAG, "start foreground service，service is stopping");
+      } else {
+        state = ServiceState.STARTING;
+        if (!checkHasPermission(context)) {
+          state = ServiceState.IDLE;
+          CallUILog.e(TAG, "start foreground service failed, please grant microphone permission");
+        } else {
+          CallUILog.d(
+              TAG, "start foreground service title=" + title + " description=" + description);
+          Intent intent = new Intent(context, AudioForegroundService.class);
+          intent.putExtra(TITLE, title);
+          intent.putExtra(ICON, icon);
+          intent.putExtra(DESCRIPTION, description);
+          if (VERSION.SDK_INT >= 26) {
+            context.startForegroundService(intent);
+          } else {
+            context.startService(intent);
+          }
+        }
+      }
+    } else {
+      CallUILog.i(TAG, "start foreground service，service is running");
+    }
+  }
+
+  public static void stop(Context context) {
+    CallUILog.d(TAG, "stop foreground service, state = " + state);
+    if (ServiceState.RUNNING == state) {
+      Intent intent = new Intent(context, AudioForegroundService.class);
+      context.stopService(intent);
+      state = ServiceState.IDLE;
+    } else if (ServiceState.STARTING == state) {
+      state = ServiceState.STOPPING;
+    }
+  }
+
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    if (intent == null) {
+      CallUILog.e("AudioForegroundService", "onStartCommand intent == null, state = " + state);
+      return Service.START_NOT_STICKY;
+    } else {
+      Context appContext = XKit.Companion.instance().getApplicationContext();
+      String title = intent.getStringExtra(TITLE);
+      String description = intent.getStringExtra(DESCRIPTION);
+      int icon = intent.getIntExtra(ICON, appContext.getApplicationInfo().icon);
+      Notification notification = this.createForegroundNotification(title, description, icon);
+      if (VERSION.SDK_INT >= 30) {
+        this.startForeground(1001, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE);
+      } else {
+        this.startForeground(1001, notification);
+      }
+
+      CallUILog.d(TAG, "onStartCommand end, state = " + state);
+      if (state == ServiceState.STOPPING) {
+        this.stopSelf();
+        state = ServiceState.IDLE;
+      } else {
+        state = ServiceState.RUNNING;
+      }
+
+      return Service.START_NOT_STICKY;
+    }
+  }
+
+  @Nullable
+  public IBinder onBind(Intent intent) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public void onTaskRemoved(Intent rootIntent) {
+    super.onTaskRemoved(rootIntent);
+    this.stopSelf();
+    state = ServiceState.IDLE;
+  }
+
+  private Notification createForegroundNotification(String title, String description, int icon) {
+    NotificationManager notificationManager =
+        (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
+    String notificationChannelId = "rtc_uikit_foreground_service";
+    if (VERSION.SDK_INT >= 26) {
+      String channelName = this.getApplicationContext().getString(R.string.ui_channel_name);
+      String channelDescription =
+          this.getApplicationContext().getString(R.string.ui_channel_description);
+      NotificationChannel notificationChannel =
+          new NotificationChannel(
+              notificationChannelId, channelName, NotificationManager.IMPORTANCE_LOW);
+      notificationChannel.setDescription(channelDescription);
+      if (notificationManager != null) {
+        notificationManager.createNotificationChannel(notificationChannel);
+      }
+    }
+
+    boolean enableNotification = true;
+    if (VERSION.SDK_INT >= 24 && notificationManager != null) {
+      enableNotification = notificationManager.areNotificationsEnabled();
+    }
+
+    CallUILog.i("AudioForegroundService", "enableNotification: " + enableNotification);
+    NotificationCompat.Builder builder =
+        new NotificationCompat.Builder(this, notificationChannelId);
+    builder.setSmallIcon(icon);
+    builder.setContentTitle(title);
+    builder.setContentText(description);
+    builder.setWhen(System.currentTimeMillis());
+    return builder.build();
+  }
+
+  private static boolean checkHasPermission(Context context) {
+    return ContextCompat.checkSelfPermission(context, "android.permission.RECORD_AUDIO") == 0;
+  }
+
+  static {
+    state = ServiceState.IDLE;
+  }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/service/foregroundservice/ServiceState.java
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/service/foregroundservice/ServiceState.java
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.nertc.ui.service.foregroundservice;
+
+public enum ServiceState {
+  IDLE,
+  STARTING,
+  RUNNING,
+  STOPPING;
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/service/foregroundservice/VideoForegroundService.java
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/service/foregroundservice/VideoForegroundService.java
@@ -1,0 +1,160 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.nertc.ui.service.foregroundservice;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.os.Build;
+import android.os.Build.VERSION;
+import android.os.IBinder;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+import com.netease.yunxin.kit.corekit.XKit;
+import com.netease.yunxin.nertc.ui.R;
+import com.netease.yunxin.nertc.ui.utils.CallUILog;
+
+public class VideoForegroundService extends Service {
+  private static final String TAG = "VideoForegroundService";
+  private static final String TITLE = "title";
+  private static final String ICON = "icon";
+  private static final String DESCRIPTION = "description";
+  private static final int NOTIFICATION_ID = 1001;
+  private static ServiceState state;
+
+  public static void start(Context context, String title, String description, int icon) {
+    if (state != ServiceState.STARTING && state != ServiceState.RUNNING) {
+      if (state == ServiceState.STOPPING) {
+        state = ServiceState.STARTING;
+        CallUILog.i(TAG, "start foreground service，service is stopping");
+      } else {
+        state = ServiceState.STARTING;
+        if (!checkHasPermission(context)) {
+          state = ServiceState.IDLE;
+          CallUILog.w(
+              TAG,
+              "start foreground service failed, please grant camera and microphone permission");
+        } else {
+          CallUILog.d(
+              TAG, "start foreground service title=" + title + " description=" + description);
+          Intent intent = new Intent(context, VideoForegroundService.class);
+          intent.putExtra(TITLE, title);
+          intent.putExtra(ICON, icon);
+          intent.putExtra(DESCRIPTION, description);
+          if (VERSION.SDK_INT >= 26) {
+            context.startForegroundService(intent);
+          } else {
+            context.startService(intent);
+          }
+        }
+      }
+    } else {
+      CallUILog.i(TAG, "start foreground service，service is running");
+    }
+  }
+
+  public static void stop(Context context) {
+    CallUILog.d(TAG, "stop foreground service: state = " + state);
+    if (ServiceState.RUNNING == state) {
+      Intent intent = new Intent(context, VideoForegroundService.class);
+      context.stopService(intent);
+      state = ServiceState.IDLE;
+    } else if (ServiceState.STARTING == state) {
+      state = ServiceState.STOPPING;
+    }
+  }
+
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    if (intent == null) {
+      CallUILog.e(TAG, "onStartCommand intent == null, state = " + state);
+      return Service.START_NOT_STICKY;
+    } else {
+      Context appContext = XKit.Companion.instance().getApplicationContext();
+      String title = intent.getStringExtra(TITLE);
+      String description = intent.getStringExtra(DESCRIPTION);
+      int icon = intent.getIntExtra(ICON, appContext.getApplicationInfo().icon);
+      Notification notification = this.createForegroundNotification(title, description, icon);
+      if (VERSION.SDK_INT >= 30) {
+        this.startForeground(
+            1001,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                | ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA);
+      } else {
+        this.startForeground(1001, notification);
+      }
+
+      CallUILog.d(TAG, "onStartCommand end, state = " + state);
+      if (state == ServiceState.STOPPING) {
+        this.stopSelf();
+        state = ServiceState.IDLE;
+      } else {
+        state = ServiceState.RUNNING;
+      }
+
+      return Service.START_NOT_STICKY;
+    }
+  }
+
+  @Nullable
+  public IBinder onBind(Intent intent) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public void onTaskRemoved(Intent rootIntent) {
+    super.onTaskRemoved(rootIntent);
+    this.stopSelf();
+    state = ServiceState.IDLE;
+  }
+
+  private Notification createForegroundNotification(String title, String description, int icon) {
+    NotificationManager notificationManager =
+        (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
+    String notificationChannelId = "callkit_foreground_service";
+    if (VERSION.SDK_INT >= 26) {
+      String channelName = this.getApplicationContext().getString(R.string.ui_channel_name);
+      String channelDescription =
+          this.getApplicationContext().getString(R.string.ui_channel_description);
+      NotificationChannel notificationChannel = null;
+      notificationChannel =
+          new NotificationChannel(
+              notificationChannelId, channelName, NotificationManager.IMPORTANCE_LOW);
+      notificationChannel.setDescription(channelDescription);
+      if (notificationManager != null) {
+        notificationManager.createNotificationChannel(notificationChannel);
+      }
+    } else {
+      CallUILog.e(TAG, "createForegroundNotification not support");
+    }
+
+    boolean enableNotification = true;
+    if (Build.VERSION.SDK_INT >= 24 && notificationManager != null) {
+      enableNotification = notificationManager.areNotificationsEnabled();
+    }
+
+    CallUILog.i("VideoForegroundService", "enableNotification: " + enableNotification);
+    NotificationCompat.Builder builder =
+        new NotificationCompat.Builder(this, notificationChannelId);
+    builder.setSmallIcon(icon);
+    builder.setContentTitle(title);
+    builder.setContentText(description);
+    builder.setWhen(System.currentTimeMillis());
+    return builder.build();
+  }
+
+  private static boolean checkHasPermission(Context context) {
+    return ContextCompat.checkSelfPermission(context, "android.permission.CAMERA") == 0
+        && ContextCompat.checkSelfPermission(context, "android.permission.RECORD_AUDIO") == 0;
+  }
+
+  static {
+    state = ServiceState.IDLE;
+  }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/utils/CallPermissionUtils.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/utils/CallPermissionUtils.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.utils
+
+import android.Manifest
+import android.content.Context
+import com.netease.yunxin.kit.call.p2p.model.NECallType
+import com.netease.yunxin.kit.common.ui.utils.Permission
+
+object CallPermissionUtils {
+
+    fun requirePermissions(context: Context, callType: Int, callback: Permission.PermissionCallback) {
+        val permissions: Array<String>
+        if (callType == NECallType.AUDIO) {
+            permissions = arrayOf(Manifest.permission.RECORD_AUDIO)
+        } else {
+            permissions = arrayOf(Manifest.permission.RECORD_AUDIO, Manifest.permission.CAMERA)
+        }
+
+        Permission.requirePermissions(context, *permissions)
+            .request(callback)
+    }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/utils/CallUILog.java
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/utils/CallUILog.java
@@ -4,37 +4,37 @@
 
 package com.netease.yunxin.nertc.ui.utils;
 
-import com.netease.yunxin.kit.alog.ALog;
 import com.netease.yunxin.kit.alog.ParameterMap;
+import com.netease.yunxin.kit.corekit.XKitLog;
 
 public class CallUILog {
   private static final String MODULE = "CallKit_UI";
 
   public static void dApi(String tag, ParameterMap msg) {
-    ALog.d(tag, msg.toValue(), MODULE);
+    XKitLog.d(tag, msg.toValue(), MODULE);
   }
 
   public static void i(String tag, String msg) {
-    ALog.i(tag, msg, MODULE);
+    XKitLog.i(tag, msg, MODULE);
   }
 
   public static void d(String tag, String msg) {
-    ALog.d(tag, msg, MODULE);
+    XKitLog.d(tag, msg, MODULE);
   }
 
   public static void w(String tag, String msg) {
-    ALog.w(tag, msg, MODULE);
+    XKitLog.w(tag, msg, MODULE);
   }
 
   public static void e(String tag, String msg) {
-    ALog.e(tag, msg, MODULE);
+    XKitLog.e(tag, msg, MODULE);
   }
 
   public static void e(String tag, String msg, Throwable throwable) {
-    ALog.e(tag, msg + ":" + throwable.getMessage(), MODULE);
+    XKitLog.e(tag, msg + ":" + throwable.getMessage(), MODULE);
   }
 
   public static void flush(boolean isSync) {
-    ALog.flush(isSync);
+    XKitLog.flush(isSync);
   }
 }

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/utils/CallUIUtils.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/utils/CallUIUtils.kt
@@ -8,13 +8,21 @@ package com.netease.yunxin.nertc.ui.utils
 
 import android.content.Context
 import android.text.TextUtils
+import android.widget.ImageView
+import com.bumptech.glide.Glide
 import com.netease.nimlib.sdk.NIMClient
+import com.netease.nimlib.sdk.RequestCallbackWrapper
+import com.netease.nimlib.sdk.nos.NosService
+import com.netease.nimlib.sdk.uinfo.UserService
+import com.netease.nimlib.sdk.uinfo.model.NimUserInfo
+import com.netease.nimlib.sdk.uinfo.model.UserInfo
 import com.netease.yunxin.kit.call.p2p.NECallEngine
 import com.netease.yunxin.kit.call.p2p.model.NEHangupReasonCode
 import com.netease.yunxin.nertc.ui.R
+import java.util.Collections
 
 object CallUIUtils {
-
+    private const val TAG = "CallUIUtils"
     fun showToastWithCallEndReason(context: Context, reasonCode: Int) {
         when (reasonCode) {
             NEHangupReasonCode.CALLER_REJECTED -> if (!isCalled()) {
@@ -53,5 +61,73 @@ object CallUIUtils {
         val calleeInfo = callInfo.calleeInfo ?: return false
         val currentAccount = NIMClient.getCurrentAccount() ?: return false
         return TextUtils.equals(calleeInfo.accId, currentAccount)
+    }
+
+    fun loadImgByAccId(context: Context, accId: String, imageView: ImageView) {
+        val applicationContext = context.applicationContext
+        val defaultResId = R.drawable.t_avchat_avatar_default
+
+        val loadAction: (String?) -> Unit = { url ->
+            Glide.with(applicationContext)
+                .load(url)
+                .placeholder(defaultResId)
+                .error(defaultResId)
+                .into(imageView)
+        }
+
+        val getLongUrlAndLoad: (String?) -> Unit = { url ->
+            if (url == null) {
+                loadAction(null)
+            } else {
+                NIMClient.getService(NosService::class.java).getOriginUrlFromShortUrl(url)
+                    .setCallback(object : RequestCallbackWrapper<String>() {
+                        override fun onResult(code: Int, result: String?, exception: Throwable?) {
+                            loadAction(result)
+                        }
+                    })
+            }
+        }
+
+        val userInfo: UserInfo? = NIMClient.getService(UserService::class.java).getUserInfo(accId)
+        if (userInfo?.avatar != null) {
+            getLongUrlAndLoad(userInfo.avatar)
+            return
+        }
+
+        NIMClient.getService(UserService::class.java).fetchUserInfo(
+            Collections.singletonList(accId)
+        )
+            .setCallback(object : RequestCallbackWrapper<List<NimUserInfo?>>() {
+                override fun onResult(
+                    code: Int,
+                    result: List<NimUserInfo?>?,
+                    exception: Throwable?
+                ) {
+                    if (result.isNullOrEmpty()) {
+                        loadAction(null)
+                        return
+                    }
+                    getLongUrlAndLoad(result[0]?.avatar)
+                }
+            })
+    }
+
+    /**
+     * 加载图片
+     */
+    fun loadImg(context: Context, url: String?, imageView: ImageView?) {
+        imageView ?: run {
+            CallUILog.e(this.TAG, "loadImg imageView is null.")
+            return
+        }
+        val currentContext = context.applicationContext ?: run {
+            CallUILog.e(this.TAG, "loadImg context is null.")
+            return
+        }
+        Glide.with(currentContext).load(url)
+            .error(R.color.black)
+            .placeholder(R.color.black)
+            .centerCrop()
+            .into(imageView)
     }
 }

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/utils/DeviceUtils.java
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/utils/DeviceUtils.java
@@ -1,0 +1,294 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+package com.netease.yunxin.nertc.ui.utils;
+
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.os.Build;
+import android.text.TextUtils;
+import java.lang.reflect.Method;
+
+public class DeviceUtils {
+  public static Boolean isSamsungDevice() {
+    String brand = Build.BRAND;
+    String manufacturer = Build.MANUFACTURER;
+    return "samsung".equalsIgnoreCase(brand) && "samsung".equalsIgnoreCase(manufacturer);
+  }
+
+  public static boolean isScreenLocked(Context context) {
+    KeyguardManager keyguardManager =
+        (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+      // >= Android 5.1
+      return keyguardManager.isDeviceLocked();
+    } else {
+      // < Android 5.1
+      return keyguardManager.inKeyguardRestrictedInputMode();
+    }
+  }
+
+  private static final String TAG = "Devices";
+  private static String MODEL = "";
+  private static String BRAND = "";
+  private static String DEVICE = "";
+  private static String MANUFACTURER = "";
+  private static String HARDWARE = "";
+  private static String VERSION = "";
+  private static String BOARD = "";
+  private static String VERSION_INCREMENTAL = "";
+  private static int VERSION_INT = 0;
+
+  public DeviceUtils() {}
+
+  public static void setModel(final String model) {
+    Class var1 = DeviceUtils.class;
+    synchronized (DeviceUtils.class) {
+      MODEL = model;
+    }
+  }
+
+  public static String getModel() {
+    if (MODEL == null || MODEL.isEmpty()) {
+      Class var0 = DeviceUtils.class;
+      synchronized (DeviceUtils.class) {
+        if (MODEL == null || MODEL.isEmpty()) {
+          MODEL = Build.MODEL;
+          CallUILog.i("Devices", "get MODEL by Build.MODEL :" + MODEL);
+        }
+      }
+    }
+
+    return MODEL;
+  }
+
+  public static void setBrand(final String brand) {
+    Class var1 = DeviceUtils.class;
+    synchronized (DeviceUtils.class) {
+      BRAND = brand;
+    }
+  }
+
+  public static String getBrand() {
+    if (BRAND == null || BRAND.isEmpty()) {
+      Class var0 = DeviceUtils.class;
+      synchronized (DeviceUtils.class) {
+        if (BRAND == null || BRAND.isEmpty()) {
+          BRAND = Build.BRAND;
+          CallUILog.i("Devices", "get BRAND by Build.BRAND :" + BRAND);
+        }
+      }
+    }
+
+    return BRAND;
+  }
+
+  public static void setDevice(final String device) {
+    Class var1 = DeviceUtils.class;
+    synchronized (DeviceUtils.class) {
+      DEVICE = device;
+    }
+  }
+
+  public static String getDevice() {
+    if (DEVICE == null || DEVICE.isEmpty()) {
+      Class var0 = DeviceUtils.class;
+      synchronized (DeviceUtils.class) {
+        if (DEVICE == null || DEVICE.isEmpty()) {
+          DEVICE = Build.DEVICE;
+          CallUILog.i("Devices", "get DEVICE by Build.DEVICE :" + DEVICE);
+        }
+      }
+    }
+
+    return DEVICE;
+  }
+
+  public static void setManufacturer(final String manufacturer) {
+    Class var1 = DeviceUtils.class;
+    synchronized (DeviceUtils.class) {
+      MANUFACTURER = manufacturer;
+    }
+  }
+
+  public static String getManufacturer() {
+    if (MANUFACTURER == null || MANUFACTURER.isEmpty()) {
+      Class var0 = DeviceUtils.class;
+      synchronized (DeviceUtils.class) {
+        if (MANUFACTURER == null || MANUFACTURER.isEmpty()) {
+          MANUFACTURER = Build.MANUFACTURER;
+          CallUILog.i("Devices", "get MANUFACTURER by Build.MANUFACTURER :" + MANUFACTURER);
+        }
+      }
+    }
+
+    return MANUFACTURER;
+  }
+
+  public static void setHardware(final String hardware) {
+    Class var1 = DeviceUtils.class;
+    synchronized (DeviceUtils.class) {
+      HARDWARE = hardware;
+    }
+  }
+
+  public static String getHardware() {
+    if (HARDWARE == null || HARDWARE.isEmpty()) {
+      Class var0 = DeviceUtils.class;
+      synchronized (DeviceUtils.class) {
+        if (HARDWARE == null || HARDWARE.isEmpty()) {
+          HARDWARE = Build.HARDWARE;
+          CallUILog.i("Devices", "get HARDWARE by Build.HARDWARE :" + HARDWARE);
+        }
+      }
+    }
+
+    return HARDWARE;
+  }
+
+  public static void setVersion(final String version) {
+    Class var1 = DeviceUtils.class;
+    synchronized (DeviceUtils.class) {
+      VERSION = version;
+    }
+  }
+
+  public static String getVersion() {
+    if (VERSION == null || VERSION.isEmpty()) {
+      Class var0 = DeviceUtils.class;
+      synchronized (DeviceUtils.class) {
+        if (VERSION == null || VERSION.isEmpty()) {
+          VERSION = Build.VERSION.RELEASE;
+          CallUILog.i("Devices", "get VERSION by Build.VERSION.RELEASE :" + VERSION);
+        }
+      }
+    }
+
+    return VERSION;
+  }
+
+  public static void setVersionInt(final int versionInt) {
+    Class var1 = DeviceUtils.class;
+    synchronized (DeviceUtils.class) {
+      VERSION_INT = versionInt;
+    }
+  }
+
+  public static int getVersionInt() {
+    if (VERSION_INT == 0) {
+      Class var0 = DeviceUtils.class;
+      synchronized (DeviceUtils.class) {
+        if (VERSION_INT == 0) {
+          VERSION_INT = Build.VERSION.SDK_INT;
+          CallUILog.i("Devices", "get VERSION_INT by Build.VERSION.SDK_INT :" + VERSION_INT);
+        }
+      }
+    }
+
+    return VERSION_INT;
+  }
+
+  public static void setVersionIncremental(final String versionIncremental) {
+    Class var1 = DeviceUtils.class;
+    synchronized (DeviceUtils.class) {
+      VERSION_INCREMENTAL = versionIncremental;
+    }
+  }
+
+  public static String getVersionIncremental() {
+    if (VERSION_INCREMENTAL == null || VERSION_INCREMENTAL.isEmpty()) {
+      Class var0 = DeviceUtils.class;
+      synchronized (DeviceUtils.class) {
+        if (VERSION_INCREMENTAL == null || VERSION_INCREMENTAL.isEmpty()) {
+          VERSION_INCREMENTAL = Build.VERSION.INCREMENTAL;
+          CallUILog.i(
+              "Devices",
+              "get VERSION_INCREMENTAL by Build.VERSION.INCREMENTAL :" + VERSION_INCREMENTAL);
+        }
+      }
+    }
+
+    return VERSION_INCREMENTAL;
+  }
+
+  public static void setBoard(final String board) {
+    Class var1 = DeviceUtils.class;
+    synchronized (DeviceUtils.class) {
+      BOARD = board;
+    }
+  }
+
+  public static String getBoard() {
+    if (BOARD == null || BOARD.isEmpty()) {
+      Class var0 = DeviceUtils.class;
+      synchronized (DeviceUtils.class) {
+        if (BOARD == null || BOARD.isEmpty()) {
+          BOARD = Build.BOARD;
+          CallUILog.i("Devices", "get BOARD by Build.BOARD :" + BOARD);
+        }
+      }
+    }
+
+    return BOARD;
+  }
+
+  public static boolean isBrandXiaoMi() {
+    return "xiaomi".equalsIgnoreCase(getBrand()) || "xiaomi".equalsIgnoreCase(getManufacturer());
+  }
+
+  public static boolean isBrandHuawei() {
+    return "huawei".equalsIgnoreCase(getBrand())
+        || "huawei".equalsIgnoreCase(getManufacturer())
+        || "honor".equalsIgnoreCase(getBrand());
+  }
+
+  public static boolean isBrandMeizu() {
+    return "meizu".equalsIgnoreCase(getBrand())
+        || "meizu".equalsIgnoreCase(getManufacturer())
+        || "22c4185e".equalsIgnoreCase(getBrand());
+  }
+
+  public static boolean isBrandOppo() {
+    return "oppo".equalsIgnoreCase(getBrand())
+        || "realme".equalsIgnoreCase(getBrand())
+        || "oneplus".equalsIgnoreCase(getBrand())
+        || "oppo".equalsIgnoreCase(getManufacturer())
+        || "realme".equalsIgnoreCase(getManufacturer())
+        || "oneplus".equalsIgnoreCase(getManufacturer());
+  }
+
+  public static boolean isBrandVivo() {
+    return "vivo".equalsIgnoreCase(getBrand()) || "vivo".equalsIgnoreCase(getManufacturer());
+  }
+
+  public static boolean isBrandHonor() {
+    return "honor".equalsIgnoreCase(getBrand()) && "honor".equalsIgnoreCase(getManufacturer());
+  }
+
+  public static boolean isHarmonyOS() {
+    try {
+      Class clz = Class.forName("com.huawei.system.BuildEx");
+      Method method = clz.getMethod("getOsBrand");
+      return "harmony".equals(method.invoke(clz));
+    } catch (Exception var2) {
+      CallUILog.e("Devices", "the phone not support the harmonyOS");
+      return false;
+    }
+  }
+
+  public static boolean isMiuiOptimization() {
+    String miuiOptimization = "";
+
+    try {
+      Class systemProperties = Class.forName("android.os.systemProperties");
+      Method get = systemProperties.getDeclaredMethod("get", String.class, String.class);
+      miuiOptimization = (String) get.invoke(systemProperties, "persist.sys.miuiOptimization", "");
+      return TextUtils.isEmpty(miuiOptimization) | "true".equals(miuiOptimization);
+    } catch (Exception var3) {
+      CallUILog.e("Devices", "the phone not support the miui optimization");
+      return false;
+    }
+  }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/view/AISubtitle.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/view/AISubtitle.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.view
+
+import android.content.Context
+import android.graphics.Typeface
+import android.os.Handler
+import android.os.Looper
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.util.AttributeSet
+import android.widget.ScrollView
+import androidx.appcompat.widget.AppCompatTextView
+import com.netease.lava.nertc.sdk.NERtcAsrCaptionResult
+import com.netease.yunxin.kit.call.p2p.NECallEngine
+import com.netease.yunxin.nertc.nertcvideocall.model.impl.NERtcCallbackExTemp
+import com.netease.yunxin.nertc.nertcvideocall.model.impl.NERtcCallbackProxyMgr
+import com.netease.yunxin.nertc.ui.base.fetchNickname
+
+class AISubtitle(context: Context, attrs: AttributeSet?) : ScrollView(context, attrs) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val translationInfo = mutableListOf<TranslationInfo>()
+    private lateinit var textView: AppCompatTextView
+    private val isShowTranslation: Boolean = false
+
+    init {
+        initView()
+    }
+
+    private fun initView() {
+        isVerticalScrollBarEnabled = true
+        isScrollbarFadingEnabled = false
+        // 设置半透明灰色背景
+        setBackgroundColor(0x80000000.toInt())
+        textView = AppCompatTextView(context).apply {
+            layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+            setPadding(16, 16, 16, 16)
+            textSize = 14f
+            setTextColor(0xFFFFFFFF.toInt())
+        }
+        addView(textView)
+    }
+
+    private val rtcCallback = object : NERtcCallbackExTemp() {
+
+        override fun onAsrCaptionResult(
+            result: Array<out NERtcAsrCaptionResult>?,
+            resultCount: Int
+        ) {
+            if (result != null) {
+                for (ret in result) {
+                    if (ret.isFinal && isShowTranslation == ret.haveTranslation) {
+                        val translationInfoItem = TranslationInfo().apply {
+                            uid = ret.uid
+                            text = if (isShowTranslation) ret.translatedText else ret.content
+                            haveTranslation = ret.haveTranslation
+                        }
+                        translationInfo.add(translationInfoItem)
+                        // 只保留最新的两条字幕
+                        if (translationInfo.size > 2) {
+                            translationInfo.removeAt(0)
+                        }
+
+                        val accId =
+                            NECallEngine.sharedInstance().getUserWithRtcUid(ret.uid)?.accId
+                        if (accId != null) {
+                            accId.fetchNickname { name ->
+                                translationInfoItem.displayName = name
+                                updateView()
+                            }
+                        } else {
+                            translationInfoItem.displayName = ret.uid.toString()
+                            updateView()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateView() {
+        val spannableBuilder = SpannableStringBuilder()
+        for ((index, message) in translationInfo.withIndex()) {
+            val displayName =
+                message.displayName
+                    ?: NECallEngine.sharedInstance().getUserWithRtcUid(message.uid)?.accId
+                    ?: message.uid.toString()
+            val fullText = "$displayName:\n${message.text}\n"
+            formatAISubtitleText(spannableBuilder, displayName, fullText)
+            if (index < translationInfo.size - 1) {
+                spannableBuilder.append("\n")
+            }
+        }
+        mainHandler.post {
+            textView.text = spannableBuilder
+            visibility = VISIBLE
+            post {
+                fullScroll(FOCUS_DOWN)
+            }
+        }
+    }
+
+    private fun formatAISubtitleText(
+        spannableBuilder: SpannableStringBuilder,
+        displayName: String,
+        fullText: String
+    ) {
+        val spannableString = SpannableString(fullText)
+        val nameStart = 0
+        val nameEnd = displayName.length + 1
+        spannableString.setSpan(
+            ForegroundColorSpan(0xFFD9CC66.toInt()),
+            nameStart,
+            nameEnd,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        spannableString.setSpan(
+            StyleSpan(Typeface.BOLD),
+            nameStart,
+            nameEnd,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        spannableBuilder.append(spannableString)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        NERtcCallbackProxyMgr.getInstance().addCallback(rtcCallback)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        NERtcCallbackProxyMgr.getInstance().removeCallback(rtcCallback)
+    }
+
+    private class TranslationInfo {
+        var uid: Long = 0
+        var text: String = ""
+        var displayName: String? = null
+        var haveTranslation = false
+    }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/view/CallLayout.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/view/CallLayout.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.view
+
+import android.content.Context
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.netease.yunxin.kit.call.p2p.model.NECallType
+import com.netease.yunxin.nertc.ui.p2p.CallUIOperationsMgr
+
+open class CallLayout(context: Context) : ConstraintLayout(context) {
+
+    init {
+        initView()
+    }
+
+    private fun initView() {
+        this.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+        if (CallUIOperationsMgr.callType == NECallType.AUDIO) {
+            addView(P2PAudioCallLayout(context), layoutParams)
+        } else {
+            addView(P2PVideoCallLayout(context), layoutParams)
+        }
+    }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/view/P2PAudioCallLayout.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/view/P2PAudioCallLayout.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.view
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.widget.ImageView
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.bumptech.glide.Glide
+import com.netease.yunxin.kit.call.p2p.model.NECallEndInfo
+import com.netease.yunxin.kit.call.p2p.model.NECallEngineDelegate
+import com.netease.yunxin.kit.call.p2p.model.NECallInfo
+import com.netease.yunxin.kit.call.p2p.model.NECallTypeChangeInfo
+import com.netease.yunxin.kit.call.p2p.model.NEInviteInfo
+import com.netease.yunxin.nertc.ui.R
+import com.netease.yunxin.nertc.ui.databinding.ViewP2pAudioOnTheCallBinding
+import com.netease.yunxin.nertc.ui.p2p.CallUIOperationsMgr
+import com.netease.yunxin.nertc.ui.utils.CallUILog
+
+open class P2PAudioCallLayout(context: Context) : ConstraintLayout(context) {
+
+    private val logTag = "SingleAudioCallLayout"
+    protected lateinit var binding: ViewP2pAudioOnTheCallBinding
+
+    init {
+        initView()
+    }
+
+    private var callDelegate = object : NECallEngineDelegate {
+        override fun onReceiveInvited(info: NEInviteInfo?) {
+            CallUILog.i(logTag, "onReceiveInvited")
+        }
+
+        override fun onCallConnected(info: NECallInfo?) {
+            CallUILog.i(logTag, "onCallConnected info: $info")
+            refreshBigVideoView()
+            refreshSmallVideoView()
+        }
+
+        override fun onCallTypeChange(info: NECallTypeChangeInfo?) {
+            CallUILog.i(logTag, "onCallTypeChange")
+        }
+
+        override fun onCallEnd(info: NECallEndInfo?) {
+            CallUILog.i(logTag, "onCallEnd")
+        }
+
+        override fun onVideoAvailable(userId: String?, available: Boolean) {
+            CallUILog.i(logTag, "onVideoAvailable")
+        }
+
+        override fun onVideoMuted(userId: String?, mute: Boolean) {
+            CallUILog.i(logTag, "onVideoMuted")
+        }
+
+        override fun onAudioMuted(userId: String?, mute: Boolean) {
+            CallUILog.i(logTag, "onAudioMuted")
+        }
+    }
+
+    private fun initBigVideoView() {
+    }
+
+    private fun refreshBigVideoView() {
+        if (CallUIOperationsMgr.callInfoWithUIState.isLocalSmallVideo) {
+        } else {
+        }
+    }
+
+    private fun refreshSmallVideoView() {
+        if (CallUIOperationsMgr.callInfoWithUIState.isLocalSmallVideo) {
+        } else {
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        registerObserver()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        unregisterObserver()
+    }
+
+    private fun initView() {
+        binding = ViewP2pAudioOnTheCallBinding.inflate(LayoutInflater.from(context), this, true)
+        initBigVideoView()
+    }
+
+    private fun registerObserver() {
+        CallUIOperationsMgr.callEngine.addCallDelegate(callDelegate)
+    }
+
+    private fun unregisterObserver() {
+        CallUIOperationsMgr.callEngine.removeCallDelegate(callDelegate)
+    }
+
+    protected open fun loadImg(url: String?, imageView: ImageView?) {
+        imageView ?: run {
+            CallUILog.e(logTag, "loadImg imageView is null.")
+            return
+        }
+        val currentContext = context.applicationContext ?: run {
+            CallUILog.e(logTag, "loadImg context is null.")
+            return
+        }
+        Glide.with(currentContext).load(url)
+            .error(R.color.black)
+            .placeholder(R.color.black)
+            .centerCrop()
+            .into(imageView)
+    }
+
+    protected fun getString(resId: Int): String {
+        return context.getString(resId)
+    }
+}

--- a/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/view/P2PVideoCallLayout.kt
+++ b/Android/call-ui/src/main/java/com/netease/yunxin/nertc/ui/view/P2PVideoCallLayout.kt
@@ -1,0 +1,759 @@
+/*
+ * Copyright (c) 2022 NetEase, Inc. All rights reserved.
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.netease.yunxin.nertc.ui.view
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.ValueAnimator
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.res.Configuration
+import android.graphics.Color
+import android.graphics.Outline
+import android.text.TextUtils
+import android.util.AttributeSet
+import android.view.GestureDetector
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewOutlineProvider
+import android.view.animation.AccelerateDecelerateInterpolator
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
+import androidx.core.content.ContextCompat
+import com.netease.lava.nertc.sdk.NERtcEx
+import com.netease.yunxin.kit.call.p2p.NECallEngine
+import com.netease.yunxin.kit.call.p2p.extra.NECallLocalActionMgr
+import com.netease.yunxin.kit.call.p2p.extra.NECallLocalActionObserver
+import com.netease.yunxin.kit.call.p2p.model.NECallEndInfo
+import com.netease.yunxin.kit.call.p2p.model.NECallEngineDelegate
+import com.netease.yunxin.kit.call.p2p.model.NECallInfo
+import com.netease.yunxin.kit.call.p2p.model.NECallType
+import com.netease.yunxin.kit.call.p2p.model.NECallTypeChangeInfo
+import com.netease.yunxin.kit.call.p2p.model.NEInviteInfo
+import com.netease.yunxin.nertc.nertcvideocall.model.CallLocalAction
+import com.netease.yunxin.nertc.nertcvideocall.model.SwitchCallState
+import com.netease.yunxin.nertc.nertcvideocall.model.impl.state.CallState
+import com.netease.yunxin.nertc.ui.R
+import com.netease.yunxin.nertc.ui.base.fetchNickname
+import com.netease.yunxin.nertc.ui.base.loadAvatarByAccId
+import com.netease.yunxin.nertc.ui.databinding.ViewP2pVideoCallBinding
+import com.netease.yunxin.nertc.ui.manager.CallManager
+import com.netease.yunxin.nertc.ui.utils.CallUILog
+import com.netease.yunxin.nertc.ui.utils.CallUIUtils
+import com.netease.yunxin.nertc.ui.utils.dip2Px
+
+open class P2PVideoCallLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr) {
+
+    private val logTag = "SingleVideoCallLayout"
+    lateinit var binding: ViewP2pVideoCallBinding
+    private var localIsSmallVideo = true
+
+    // 贴边动画相关
+    private var positionAnimator: ValueAnimator? = null
+    private var isDragging = false
+    private var dragStartX: Float = 0f
+    private var dragStartY: Float = 0f
+    private var totalDragDistanceX: Float = 0f
+    private var totalDragDistanceY: Float = 0f
+
+    init {
+        initView()
+    }
+
+    private var callDelegate = object : NECallEngineDelegate {
+        override fun onReceiveInvited(info: NEInviteInfo?) {
+            CallUILog.i(logTag, "onReceiveInvited info: $info")
+        }
+
+        override fun onCallConnected(info: NECallInfo?) {
+            CallUILog.i(logTag, "onCallConnected info: $info")
+            info?.otherUserInfo()?.accId.let {
+                renderForOnTheCall(info?.callType, it)
+            }
+        }
+
+        override fun onCallTypeChange(info: NECallTypeChangeInfo) {
+            CallUILog.i(logTag, "onCallTypeChange info: $info")
+            val callInfo = NECallEngine.sharedInstance().callInfo
+            when (info.state) {
+                SwitchCallState.ACCEPT -> {
+                    if (NECallEngine.sharedInstance().callInfo.callStatus != CallState.STATE_DIALOG) {
+                        if (callInfo.isCaller) {
+                            renderForCaller(info.callType, callInfo.calleeInfo.accId)
+                        } else {
+                            renderForCalled(info.callType, callInfo.callerInfo.accId)
+                        }
+                    } else {
+                        renderForOnTheCall(info.callType, callInfo.otherUserInfo().accId)
+                    }
+                }
+            }
+        }
+
+        override fun onCallEnd(info: NECallEndInfo?) {
+            CallUILog.i(logTag, "onCallEnd info: $info")
+        }
+
+        override fun onVideoAvailable(userId: String, available: Boolean) {
+            CallUILog.i(logTag, "onVideoAvailable userId: $userId available: $available")
+            updateOnTheCallState(UserState(userId, muteVideo = !available))
+        }
+
+        override fun onVideoMuted(userId: String, mute: Boolean) {
+            CallUILog.i(logTag, "onVideoMuted userId: $userId mute: $mute")
+            updateOnTheCallState(UserState(userId, muteVideo = mute))
+        }
+
+        override fun onAudioMuted(userId: String?, mute: Boolean) {
+            CallUILog.i(logTag, "onAudioMuted userId: $userId mute: $mute")
+        }
+    }
+
+    private val localActionObserver = NECallLocalActionObserver { actionId, resultCode, _ ->
+        CallUILog.d(logTag, "onLocalAction actionId: $actionId resultCode: $resultCode")
+        val callInfo = NECallEngine.sharedInstance().callInfo
+        if (actionId == CallLocalAction.ACTION_MUTE_VIDEO) {
+            updateOnTheCallState(
+                UserState(
+                    callInfo.currentAccId,
+                    muteVideo = true
+                )
+            )
+        } else if (actionId == CallLocalAction.ACTION_UNMUTE_VIDEO) {
+            updateOnTheCallState(
+                UserState(
+                    callInfo.currentAccId,
+                    muteVideo = false
+                )
+            )
+        } else if (actionId == CallLocalAction.ACTION_CALL) {
+            if (callInfo.isCaller) {
+                renderForCaller(callInfo.callType, callInfo.calleeInfo.accId)
+            } else {
+                renderForCalled(callInfo.callType, callInfo.callerInfo.accId)
+            }
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        registerObserver()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        // 取消正在进行的动画
+        positionAnimator?.cancel()
+        positionAnimator = null
+        unregisterObserver()
+        NERtcEx.getInstance().setupLocalVideoCanvas(null)
+        NERtcEx.getInstance().stopVideoPreview()
+    }
+
+    private fun initView() {
+        CallUILog.i(logTag, "initView")
+        binding = ViewP2pVideoCallBinding.inflate(LayoutInflater.from(context), this, true)
+        binding.flSmallContainer.setOnClickListener {
+            val callInfo = NECallEngine.sharedInstance().callInfo
+            if (callInfo.callType == NECallType.VIDEO) {
+                doSwitchCanvas()
+            }
+        }
+
+        binding.flSmallContainer.outlineProvider = object : ViewOutlineProvider() {
+            override fun getOutline(view: View, outline: Outline) {
+                outline.setRoundRect(0, 0, view.width, view.height, 8F)
+                outline.alpha = 1.0f
+            }
+        }
+        binding.flSmallContainer.setClipToOutline(true)
+
+        val callInfo = NECallEngine.sharedInstance().callInfo
+        CallUILog.i(logTag, "initView callStatus: ${callInfo.callStatus}")
+        if (callInfo.callStatus == CallState.STATE_CALL_OUT || callInfo.callStatus == CallState.STATE_INVITED) {
+            if (callInfo.isCaller) {
+                renderForCaller(callInfo.callType, callInfo.calleeInfo.accId)
+            } else {
+                renderForCalled(callInfo.callType, callInfo.callerInfo.accId)
+            }
+        } else if (callInfo.callStatus == CallState.STATE_DIALOG) {
+            renderForOnTheCall(
+                callInfo.callType,
+                callInfo.otherUserInfo().accId
+            )
+            updateCurrentState()
+        }
+    }
+
+    /**
+     * 渲染主叫状态
+     */
+    fun renderForCaller(callType: Int, calledAccId: String) {
+        forUserInfoUI(callType, calledAccId, forVideoCaller = true)
+        if (callType == NECallType.VIDEO) {
+            binding.videoViewBig.visibility = View.GONE
+            binding.videoViewPreview.visibility = View.VISIBLE
+            binding.videoViewSmall.visibility = View.GONE
+            binding.ivBg.visibility = View.GONE
+            CallManager.instance.setupLocalView(binding.videoViewPreview)
+        } else {
+            binding.ivBg.visibility = View.VISIBLE
+            binding.videoViewBig.visibility = View.GONE
+            binding.videoViewPreview.visibility = View.GONE
+            binding.videoViewSmall.visibility = View.GONE
+        }
+    }
+
+    /**
+     * 渲染被叫状态
+     */
+    fun renderForCalled(callType: Int, callerAccId: String) {
+        forUserInfoUI(callType, callerAccId)
+        if (callType == NECallType.VIDEO) {
+            binding.videoViewPreview.visibility = View.VISIBLE
+            binding.videoViewBig.visibility = View.GONE
+            binding.videoViewSmall.visibility = View.GONE
+            binding.ivBg.visibility = View.GONE
+            binding.tvOtherCallTip.setText(R.string.tip_invite_to_video_call)
+            CallManager.instance.setupLocalView(binding.videoViewPreview)
+        } else {
+            binding.videoViewPreview.visibility = View.GONE
+            binding.videoViewBig.visibility = View.GONE
+            binding.videoViewSmall.visibility = View.GONE
+            binding.ivBg.visibility = View.VISIBLE
+            binding.tvOtherCallTip.setText(R.string.tip_invite_to_audio_call)
+        }
+    }
+
+    /**
+     * 渲染通话中状态
+     */
+    fun renderForOnTheCall(callType: Int? = NECallType.VIDEO, userAccId: String? = null) {
+        val callInfo = NECallEngine.sharedInstance().callInfo
+        if (callType == NECallType.VIDEO) {
+            forUserInfoUI(callType, visible = false)
+
+            binding.videoViewPreview.visibility = View.GONE
+            binding.videoViewSmall.visibility = View.VISIBLE
+            binding.videoViewBig.visibility = View.VISIBLE
+            binding.ivSmallVideoShade.visibility = View.GONE
+            binding.ivBg.visibility = View.GONE
+
+            if (callInfo.isCaller) {
+                NERtcEx.getInstance().setupLocalVideoCanvas(null)
+                NERtcEx.getInstance().stopVideoPreview()
+            }
+
+            // 初始化手势监听器，支持拖动和点击切换
+            initGestureListener(binding.flSmallContainer)
+
+            CallManager.instance.setupRemoteView(binding.videoViewBig)
+            binding.videoViewPreview.release()
+            CallManager.instance.setupLocalView(binding.videoViewSmall)
+        } else {
+            forUserInfoUI(NECallType.AUDIO, userAccId)
+
+            binding.tvOtherCallTip.setText(R.string.tip_on_the_call)
+            binding.videoViewPreview.visibility = View.GONE
+            binding.videoViewSmall.visibility = View.GONE
+            binding.videoViewBig.visibility = View.GONE
+            binding.ivSmallVideoShade.visibility = View.GONE
+            binding.tvBigVideoCloseTip.visibility = View.GONE
+            binding.ivBg.visibility = View.VISIBLE
+        }
+    }
+
+    private fun registerObserver() {
+        NECallEngine.sharedInstance().addCallDelegate(callDelegate)
+        NECallLocalActionMgr.getInstance().addCallback(localActionObserver)
+    }
+
+    private fun unregisterObserver() {
+        NECallEngine.sharedInstance().removeCallDelegate(callDelegate)
+        NECallLocalActionMgr.getInstance().removeCallback(localActionObserver)
+    }
+
+    /**
+     * 切换画布
+     */
+    open fun doSwitchCanvas() {
+        CallUILog.i(logTag, "doSwitchCanvas")
+        val callInfo = NECallEngine.sharedInstance().callInfo
+        val otherRtcUid = callInfo.otherUserInfo().uid
+        if (otherRtcUid == 0L) {
+            CallUILog.e(
+                logTag,
+                "doSwitchCanvas otherRtcUid is 0L with accId ${callInfo.otherUserInfo().accId}."
+            )
+            return
+        }
+        if (CallManager.instance.isLocalMuteVideo) {
+            binding.videoViewBig.clearImage()
+            binding.videoViewSmall.clearImage()
+        }
+
+        if (localIsSmallVideo) {
+            NERtcEx.getInstance().setupRemoteVideoCanvas(binding.videoViewSmall, otherRtcUid)
+            NERtcEx.getInstance().setupLocalVideoCanvas(binding.videoViewBig)
+        } else {
+            NERtcEx.getInstance().setupRemoteVideoCanvas(binding.videoViewBig, otherRtcUid)
+            NERtcEx.getInstance().setupLocalVideoCanvas(binding.videoViewSmall)
+        }
+        localIsSmallVideo = !localIsSmallVideo
+        updateCurrentState()
+    }
+
+    fun updateCurrentState() {
+        CallUILog.i(logTag, "updateCurrentState")
+        val callInfo = NECallEngine.sharedInstance().callInfo
+
+        updateOnTheCallState(
+            UserState(
+                callInfo.currentUserInfo().accId,
+                muteVideo = callInfo.currentUserInfo().isMuteVideo
+            )
+        )
+
+        val otherRtcUid = callInfo.otherUserInfo().uid
+        if (otherRtcUid == 0L) {
+            CallUILog.e(
+                logTag,
+                "updateCurrentState otherRtcUid is 0L with accId ${callInfo.otherUserInfo().accId}."
+            )
+            return
+        }
+
+        updateOnTheCallState(
+            UserState(
+                callInfo.otherUserInfo().accId,
+                muteVideo = callInfo.otherUserInfo().isMuteVideo
+            )
+        )
+    }
+
+    /**
+     * 更新通话中状态
+     */
+    open fun updateOnTheCallState(state: UserState) {
+        val callInfo = NECallEngine.sharedInstance().callInfo
+
+        if (callInfo.callType == NECallType.AUDIO) {
+            CallUILog.i(logTag, "updateOnTheCallState callType is AUDIO.")
+            return
+        }
+
+        CallUILog.i(
+            logTag,
+            "updateOnTheCallState state: $state localIsSmallVideo: $localIsSmallVideo"
+        )
+        if (localIsSmallVideo) {
+            if (TextUtils.equals(state.userAccId, callInfo.currentAccId)) {
+                state.muteVideo?.run {
+                    CallUIUtils.loadImg(context, "", binding.ivSmallVideoShade)
+                    binding.ivSmallVideoShade.visibility = if (this) View.VISIBLE else View.GONE
+                    binding.tvSmallVideoCloseTip.visibility = if (this) View.VISIBLE else View.GONE
+                    binding.tvSmallVideoCloseTip.text = context.getString(
+                        R.string.ui_tip_close_camera_by_self
+                    )
+                }
+            } else {
+                state.muteVideo?.run {
+                    CallUIUtils.loadImg(context, "", binding.ivBigVideoShade)
+                    binding.ivBigVideoShade.visibility = if (this) View.VISIBLE else View.GONE
+                    binding.tvBigVideoCloseTip.text = context.getString(
+                        R.string.ui_tip_close_camera_by_other
+                    )
+                    binding.tvBigVideoCloseTip.visibility = if (this) View.VISIBLE else View.GONE
+                }
+            }
+        } else {
+            if (TextUtils.equals(state.userAccId, callInfo.currentAccId)) {
+                state.muteVideo?.run {
+                    CallUIUtils.loadImg(context, "", binding.ivBigVideoShade)
+                    binding.ivBigVideoShade.visibility = if (this) View.VISIBLE else View.GONE
+                    binding.tvBigVideoCloseTip.text = context.getString(
+                        R.string.ui_tip_close_camera_by_self
+                    )
+                    binding.tvBigVideoCloseTip.visibility = if (this) View.VISIBLE else View.GONE
+                }
+            } else {
+                state.muteVideo?.run {
+                    CallUIUtils.loadImg(context, "", binding.ivSmallVideoShade)
+                    binding.ivSmallVideoShade.visibility = if (this) View.VISIBLE else View.GONE
+                    binding.tvSmallVideoCloseTip.visibility = if (this) View.VISIBLE else View.GONE
+                    binding.tvSmallVideoCloseTip.text = context.getString(
+                        R.string.ui_tip_close_camera_by_other
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * 渲染用户信息UI
+     */
+    open fun forUserInfoUI(
+        type: Int,
+        accId: String? = null,
+        visible: Boolean = true,
+        forVideoCaller: Boolean = false
+    ) {
+        if (!visible) {
+            binding.userInfoGroup.visibility = View.GONE
+            return
+        }
+        binding.userInfoGroup.visibility = View.VISIBLE
+
+        accId?.run {
+            fetchNickname {
+                binding.tvUserName.text = it
+            }
+            loadAvatarByAccId(
+                context,
+                binding.ivUserInnerAvatar,
+                binding.ivBg,
+                binding.tvUserInnerAvatar,
+                true
+            )
+        }
+        val centerSize = 97.dip2Px(context)
+        val topSize = 60.dip2Px(context)
+
+        val constraintSet = ConstraintSet()
+        constraintSet.clone(binding.clRoot)
+        constraintSet.clear(R.id.flUserAvatar)
+        constraintSet.clear(R.id.tvOtherCallTip)
+        constraintSet.clear(R.id.tvUserName)
+        constraintSet.constrainHeight(R.id.tvOtherCallTip, ConstraintSet.WRAP_CONTENT)
+        constraintSet.constrainWidth(R.id.tvOtherCallTip, ConstraintSet.WRAP_CONTENT)
+        constraintSet.constrainWidth(R.id.tvUserName, ConstraintSet.WRAP_CONTENT)
+
+        if (type == NECallType.VIDEO && forVideoCaller) {
+            val marginSize16 = 16.dip2Px(context)
+            val marginTop = 50.dip2Px(context)
+            binding.flUserAvatar.run {
+                constraintSet.constrainWidth(id, topSize)
+                constraintSet.constrainHeight(id, topSize)
+                constraintSet.connect(
+                    id,
+                    ConstraintSet.END,
+                    ConstraintSet.PARENT_ID,
+                    ConstraintSet.END,
+                    marginSize16
+                )
+                constraintSet.connect(
+                    id,
+                    ConstraintSet.TOP,
+                    ConstraintSet.PARENT_ID,
+                    ConstraintSet.TOP,
+                    marginTop
+                )
+            }
+            val marginSize10 = 10.dip2Px(context)
+            val marginSize5 = 5.dip2Px(context)
+            binding.tvUserName.run {
+                textSize = 18f
+                constraintSet.connect(
+                    id,
+                    ConstraintSet.END,
+                    binding.flUserAvatar.id,
+                    ConstraintSet.START,
+                    marginSize10
+                )
+                constraintSet.connect(
+                    id,
+                    ConstraintSet.TOP,
+                    binding.flUserAvatar.id,
+                    ConstraintSet.TOP,
+                    marginSize5
+                )
+            }
+            binding.tvOtherCallTip.run {
+                setTextColor(ContextCompat.getColor(context, R.color.white))
+                constraintSet.connect(
+                    id,
+                    ConstraintSet.TOP,
+                    binding.tvUserName.id,
+                    ConstraintSet.BOTTOM,
+                    marginSize5
+                )
+                constraintSet.connect(
+                    id,
+                    ConstraintSet.END,
+                    binding.flUserAvatar.id,
+                    ConstraintSet.START,
+                    marginSize10
+                )
+            }
+        } else {
+            binding.flUserAvatar.run {
+                constraintSet.constrainWidth(id, centerSize)
+                constraintSet.constrainHeight(id, centerSize)
+                constraintSet.connect(
+                    id,
+                    ConstraintSet.TOP,
+                    ConstraintSet.PARENT_ID,
+                    ConstraintSet.TOP,
+                    160.dip2Px(context)
+                )
+                constraintSet.centerHorizontally(id, ConstraintSet.PARENT_ID)
+            }
+            binding.tvUserName.run {
+                textSize = 20f
+                constraintSet.centerHorizontally(id, ConstraintSet.PARENT_ID)
+                constraintSet.connect(
+                    id,
+                    ConstraintSet.TOP,
+                    binding.flUserAvatar.id,
+                    ConstraintSet.BOTTOM,
+                    15.dip2Px(context)
+                )
+            }
+            binding.tvOtherCallTip.run {
+                setTextColor(ContextCompat.getColor(context, R.color.color_cccccc))
+                constraintSet.connect(
+                    id,
+                    ConstraintSet.TOP,
+                    binding.tvUserName.id,
+                    ConstraintSet.BOTTOM,
+                    8.dip2Px(context)
+                )
+                constraintSet.centerHorizontally(id, ConstraintSet.PARENT_ID)
+            }
+        }
+        constraintSet.applyTo(binding.clRoot)
+    }
+
+    /**
+     * 重置切换状态
+     */
+    open fun resetSwitchState(callType: Int) {
+        if (callType == NECallType.VIDEO) {
+            localIsSmallVideo = true
+            binding.tvBigVideoCloseTip.visibility = View.GONE
+            binding.videoViewSmall.setBackgroundColor(Color.TRANSPARENT)
+        }
+    }
+
+    /**
+     * 初始化手势监听器，支持拖动和点击切换
+     * @param view 需要添加手势的视图
+     */
+    @SuppressLint("ClickableViewAccessibility")
+    private fun initGestureListener(view: View) {
+        val detector = GestureDetector(
+            context,
+            object : GestureDetector.SimpleOnGestureListener() {
+                override fun onSingleTapUp(e: MotionEvent): Boolean {
+                    // 单击事件：切换画布（只有在非拖动状态下才响应）
+                    if (!isDragging) {
+                        view.performClick()
+                    }
+                    return true
+                }
+
+                override fun onDown(e: MotionEvent): Boolean {
+                    // 取消正在进行的贴边动画
+                    positionAnimator?.cancel()
+                    isDragging = false
+                    // 记录拖动起始位置
+                    dragStartX = e.x
+                    dragStartY = e.y
+                    totalDragDistanceX = 0f
+                    totalDragDistanceY = 0f
+                    return true
+                }
+
+                override fun onScroll(
+                    e1: MotionEvent?,
+                    e2: MotionEvent,
+                    distanceX: Float,
+                    distanceY: Float
+                ): Boolean {
+                    // 标记为拖动状态
+                    isDragging = true
+
+                    // 累计拖动距离（用于判断拖动方向）
+                    totalDragDistanceX += Math.abs(distanceX)
+                    totalDragDistanceY += Math.abs(distanceY)
+
+                    // 拖动事件：移动小窗口位置
+                    val layoutParams = view.layoutParams as ConstraintLayout.LayoutParams
+                    val offsetX = if (isRTL) {
+                        // RTL 布局：从右到左，需要反转 X 方向
+                        e2.x - (e1?.x ?: 0f)
+                    } else {
+                        // LTR 布局：从左到右
+                        (e1?.x ?: 0f) - e2.x
+                    }
+
+                    val newX = (layoutParams.marginEnd + offsetX).toInt()
+                    val newY = (layoutParams.topMargin + (e2.y - (e1?.y ?: 0f))).toInt()
+
+                    // 边界检查，确保小窗口不会移出屏幕
+                    val maxX = width - view.width
+                    val maxY = height - view.height
+
+                    if (newX >= 0 && newX <= maxX && newY >= 0 && newY <= maxY) {
+                        layoutParams.marginEnd = newX
+                        layoutParams.topMargin = newY
+                        view.layoutParams = layoutParams
+                        CallUILog.d(logTag, "onScroll: newX=$newX, newY=$newY")
+                    }
+                    return true
+                }
+            }
+        )
+
+        view.setOnTouchListener { v, event ->
+            val result = detector.onTouchEvent(event)
+
+            // 处理 ACTION_UP 事件，实现贴边效果
+            if (event.action == MotionEvent.ACTION_UP || event.action == MotionEvent.ACTION_CANCEL) {
+                if (isDragging) {
+                    // 拖动结束后，自动贴边
+                    snapToEdge(view)
+                    isDragging = false
+                }
+            }
+
+            result
+        }
+    }
+
+    /**
+     * 将小窗口吸附到最近的边缘
+     * @param view 需要贴边的小窗口视图
+     */
+    private fun snapToEdge(view: View) {
+        val layoutParams = view.layoutParams as ConstraintLayout.LayoutParams
+        val currentX = layoutParams.marginEnd
+        val currentY = layoutParams.topMargin
+
+        val viewWidth = view.width
+        val viewHeight = view.height
+        val parentWidth = width
+        val parentHeight = height
+
+        // 判断是否为纯垂直拖动（垂直拖动距离明显大于水平拖动距离）
+        val isPureVerticalDrag = totalDragDistanceY > totalDragDistanceX * 2.0f
+
+        // 计算小窗口左边缘的 X 坐标（用于判断贴哪一边）
+        // 注意：marginEnd 是右边距，需要转换为左边缘位置
+        val leftEdgeX = parentWidth - currentX - viewWidth
+        val centerY = currentY + viewHeight / 2
+
+        // X 轴贴边逻辑：
+        // 小窗口始终贴到最近的边（左边或右边），除非是纯垂直拖动
+        val targetX = if (isPureVerticalDrag) {
+            // 纯垂直拖动：X 坐标保持不变
+            currentX
+        } else {
+            // 判断贴左边还是右边（基于左边缘位置）
+            if (leftEdgeX < parentWidth / 2) {
+                // 贴左边：marginEnd = parentWidth - viewWidth
+                parentWidth - viewWidth
+            } else {
+                // 贴右边：marginEnd = 0
+                0
+            }
+        }
+
+        // Y 轴贴边逻辑：Y 坐标保持不变（确保在边界内）
+        val targetY = currentY.coerceIn(0, parentHeight - viewHeight)
+
+        CallUILog.d(
+            logTag,
+            "snapToEdge: isPureVerticalDrag=$isPureVerticalDrag, leftEdgeX=$leftEdgeX, currentX=$currentX, currentY=$currentY, targetX=$targetX, targetY=$targetY"
+        )
+
+        // 如果位置没有变化，不需要动画
+        if (currentX == targetX && currentY == targetY) {
+            return
+        }
+
+        // 使用动画平滑移动到目标位置
+        animateToPosition(view, currentX, currentY, targetX, targetY)
+    }
+
+    /**
+     * 使用动画将视图移动到目标位置
+     */
+    private fun animateToPosition(
+        view: View,
+        startX: Int,
+        startY: Int,
+        endX: Int,
+        endY: Int
+    ) {
+        // 取消之前的动画
+        positionAnimator?.cancel()
+
+        val layoutParams = view.layoutParams as ConstraintLayout.LayoutParams
+
+        // 创建 X 和 Y 的动画
+        val animatorX = ValueAnimator.ofInt(startX, endX)
+        val animatorY = ValueAnimator.ofInt(startY, endY)
+
+        animatorX.duration = 200
+        animatorX.interpolator = AccelerateDecelerateInterpolator()
+        animatorX.addUpdateListener { animation ->
+            val x = animation.animatedValue as Int
+            layoutParams.marginEnd = x
+            view.layoutParams = layoutParams
+        }
+
+        animatorY.duration = 200
+        animatorY.interpolator = AccelerateDecelerateInterpolator()
+        animatorY.addUpdateListener { animation ->
+            val y = animation.animatedValue as Int
+            layoutParams.topMargin = y
+            view.layoutParams = layoutParams
+        }
+
+        // 同时启动 X 和 Y 的动画
+        positionAnimator = animatorX
+        animatorX.start()
+        animatorY.start()
+
+        // 动画结束后清理
+        animatorX.addListener(object : AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: Animator) {
+                positionAnimator = null
+                CallUILog.d(
+                    logTag,
+                    "snapToEdge animation end: finalX=${layoutParams.marginEnd}, finalY=${layoutParams.topMargin}"
+                )
+            }
+        })
+    }
+
+    /**
+     * 判断是否为 RTL（从右到左）布局
+     */
+    private val isRTL: Boolean
+        get() = context.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL
+
+    override fun onConfigurationChanged(newConfig: Configuration?) {
+        super.onConfigurationChanged(newConfig)
+        // 配置变化时，可能需要重新调整小窗口位置
+        binding.videoViewSmall.requestLayout()
+    }
+
+    /**
+     * 用户状态
+     */
+    data class UserState(
+        val userAccId: String,
+        val muteVideo: Boolean? = null
+    )
+}

--- a/Android/call-ui/src/main/res/drawable/callkit_ui_permission_dialog_bg.xml
+++ b/Android/call-ui/src/main/res/drawable/callkit_ui_permission_dialog_bg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/white"/>
+    <corners android:radius="7.68dp"/>
+</shape>

--- a/Android/call-ui/src/main/res/layout/activity_floating_window.xml
+++ b/Android/call-ui/src/main/res/layout/activity_floating_window.xml
@@ -25,12 +25,13 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-            android:id="@+id/tvRemoteVideoCloseTip"
+            android:id="@+id/tvSmallVideoCloseTip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/ui_tip_close_camera_by_other"
             android:background="@drawable/close_video_tip_bg"
             android:textSize="11sp"
+            android:gravity="center"
             android:padding="10dp"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/Android/call-ui/src/main/res/layout/activity_p2_pcall.xml
+++ b/Android/call-ui/src/main/res/layout/activity_p2_pcall.xml
@@ -13,115 +13,23 @@
     android:background="@color/black"
     tools:ignore="ContentDescription,SpUsage">
 
-    <!--视频通话远端用户视频画面-->
-    <com.netease.lava.nertc.sdk.video.NERtcVideoView
-        android:id="@+id/videoViewBig"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <ImageView
-        android:id="@+id/ivBigVideoShade"
+    <!-- SingleVideoCallLayout 容器，包含所有非按钮的 view -->
+    <com.netease.yunxin.nertc.ui.view.P2PVideoCallLayout
+        android:id="@+id/singleVideoCallLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
-
-    <!--视频通话本地用户预览大视频画面-->
-    <com.netease.lava.nertc.sdk.video.NERtcVideoView
-        android:id="@+id/videoViewPreview"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <!--视频通话本地用户预览小视频画面-->
-    <com.netease.lava.nertc.sdk.video.NERtcVideoView
-        android:id="@+id/videoViewSmall"
-        android:layout_width="90dp"
-        android:layout_height="160dp"
-        android:layout_margin="16dp"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <ImageView
-        android:id="@+id/ivSmallVideoShade"
-        android:layout_width="90dp"
-        android:layout_height="160dp"
-        android:layout_margin="16dp"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-
-    <ImageView
-        android:id="@+id/ivBg"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
-
-    <!-- 视频呼叫页面顶部用户信息 start -->
-    <FrameLayout
-        android:id="@+id/flUserAvatar"
-        android:layout_width="60dp"
-        android:layout_height="60dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="18dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/tvUserInnerAvatar"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:textSize="25dp"
-            android:textStyle="bold" />
-
-        <ImageView
-            android:id="@+id/ivUserInnerAvatar"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:src="@drawable/t_avchat_avatar_default" />
-    </FrameLayout>
+        android:layout_height="match_parent" />
 
     <TextView
-        android:id="@+id/tvUserName"
+        android:id="@+id/tvCountdown"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:layout_marginEnd="10dp"
-        android:textColor="@color/colorWhite"
-        android:textSize="18dp"
-        app:layout_constraintEnd_toStartOf="@id/flUserAvatar"
-        app:layout_constraintTop_toTopOf="@id/flUserAvatar" />
-
-    <TextView
-        android:id="@+id/tvOtherCallTip"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:layout_marginEnd="10dp"
-        android:text="@string/ui_tip_waiting_to_accept_for_audio"
-        android:textColor="@color/colorWhite"
+        android:layout_marginTop="3dp"
+        android:textColor="@color/color_cccccc"
         android:textSize="14dp"
-        app:layout_constraintEnd_toStartOf="@id/flUserAvatar"
-        app:layout_constraintTop_toBottomOf="@id/tvUserName" />
-
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/userInfoGroup"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:visibility="gone"
-        app:constraint_referenced_ids="flUserAvatar,tvUserName,tvOtherCallTip" />
-    <!-- 视频呼叫页面顶部用户信息 end -->
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/ivSwitchCamera"
@@ -191,20 +99,6 @@
             android:src="@drawable/hangup" />
     </LinearLayout>
     <!-- 通话中操作布局 end -->
-
-    <TextView
-        android:id="@+id/tvRemoteVideoCloseTip"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/ui_tip_close_camera_by_other"
-        android:background="@drawable/close_video_tip_bg"
-        android:textSize="20sp"
-        android:padding="10dp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
     <!-- 被叫用户邀请操作控制 start-->
     <ImageView
@@ -420,18 +314,6 @@
         android:visibility="gone"
         app:constraint_referenced_ids="ivCallMuteAudio,ivCallSpeaker,tvCallMuteAudioTip,tvCallSpeakerTip" />
     <!-- 主叫用户呼叫操作控制 end-->
-
-    <TextView
-        android:id="@+id/tvCountdown"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="3dp"
-        android:textColor="@color/color_cccccc"
-        android:textSize="14dp"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/tvSwitchTip"

--- a/Android/call-ui/src/main/res/layout/activity_permission_layout.xml
+++ b/Android/call-ui/src/main/res/layout/activity_permission_layout.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/call_ui_permission_layout"
+    android:orientation="vertical"
+    android:background="#BF000000"
+    android:gravity="center_horizontal"
+    android:paddingTop="60dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/permission_icon"
+        android:scaleType="fitCenter"
+        android:layout_gravity="center"
+        android:layout_width="32dp"
+        android:layout_height="32dp"/>
+
+    <TextView
+        android:id="@+id/permission_reason_title"
+        android:textSize="17.28sp"
+        android:textColor="@color/white"
+        android:textStyle="bold"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:layout_width="240dp"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/permission_reason"
+        android:layout_marginTop="8dp"
+        android:textSize="17sp"
+        android:gravity="center"
+        android:textColor="#BFFFFFFF"
+        android:layout_width="240dp"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/Android/call-ui/src/main/res/layout/fragment_p2p_audio_on_the_call.xml
+++ b/Android/call-ui/src/main/res/layout/fragment_p2p_audio_on_the_call.xml
@@ -155,6 +155,16 @@
         app:layout_constraintEnd_toEndOf="@id/tvSwitchTip"
         app:layout_constraintTop_toTopOf="@id/tvSwitchTip" />
 
+    <com.netease.yunxin.nertc.ui.view.AISubtitle
+        android:id="@+id/subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_marginTop="10dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/llOnTheCallOperation"
+        android:visibility="gone"/>
+
     <androidx.constraintlayout.widget.Group
         android:id="@+id/switchTypeTipGroup"
         android:visibility="gone"

--- a/Android/call-ui/src/main/res/layout/fragment_p2p_video_on_the_call.xml
+++ b/Android/call-ui/src/main/res/layout/fragment_p2p_video_on_the_call.xml
@@ -179,6 +179,16 @@
         app:layout_constraintEnd_toEndOf="@id/tvSwitchTip"
         app:layout_constraintTop_toTopOf="@id/tvSwitchTip" />
 
+    <com.netease.yunxin.nertc.ui.view.AISubtitle
+        android:id="@+id/subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_marginTop="10dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/llOnTheCallOperation"
+        android:visibility="gone"/>
+
     <androidx.constraintlayout.widget.Group
         android:id="@+id/switchTypeTipGroup"
         android:visibility="gone"

--- a/Android/call-ui/src/main/res/layout/view_p2p_audio_on_the_call.xml
+++ b/Android/call-ui/src/main/res/layout/view_p2p_audio_on_the_call.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2022 NetEase, Inc. All rights reserved.
+  ~ Use of this source code is governed by a MIT license that can be
+  ~ found in the LICENSE file.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/clRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/black"
+    tools:ignore="ContentDescription,SpUsage">
+
+    <ImageView
+        android:id="@+id/ivBg"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <!-- 视频呼叫页面顶部用户信息 start -->
+    <FrameLayout
+        android:id="@+id/flUserAvatar"
+        android:layout_width="90dp"
+        android:layout_height="90dp"
+        android:layout_marginTop="160dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/ivUserInnerAvatar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:src="@drawable/t_avchat_avatar_default" />
+
+        <TextView
+            android:id="@+id/tvUserInnerAvatar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:textSize="25dp"
+            android:textStyle="bold" />
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/tvUserName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:textColor="@color/colorWhite"
+        android:textSize="18dp"
+        app:layout_constraintStart_toStartOf="@id/flUserAvatar"
+        app:layout_constraintEnd_toEndOf="@id/flUserAvatar"
+        app:layout_constraintTop_toBottomOf="@id/flUserAvatar" />
+
+    <TextView
+        android:id="@+id/tvOtherCallTip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/tip_on_the_call"
+        android:textColor="@color/colorWhite"
+        android:textSize="14dp"
+        app:layout_constraintStart_toStartOf="@id/tvUserName"
+        app:layout_constraintTop_toBottomOf="@id/tvUserName"
+        app:layout_constraintEnd_toEndOf="@id/tvUserName" />
+    <!-- 视频呼叫页面顶部用户信息 end -->
+
+    <TextView
+        android:id="@+id/tvCountdown"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="3dp"
+        android:textColor="@color/color_cccccc"
+        android:textSize="14dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tvSwitchTip"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp"
+        android:background="#40000000"
+        android:gravity="center_vertical"
+        android:padding="10dp"
+        android:text="@string/ui_switch_call_type_request_tip"
+        android:textSize="14dp"
+        android:layout_marginTop="80dp"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/ivSwitchTipClose"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginEnd="5dp"
+        android:alpha="0.4"
+        android:gravity="center"
+        android:padding="12dp"
+        android:src="@drawable/icon_switch_call_type_close"
+        app:layout_constraintBottom_toBottomOf="@+id/tvSwitchTip"
+        app:layout_constraintEnd_toEndOf="@id/tvSwitchTip"
+        app:layout_constraintTop_toTopOf="@id/tvSwitchTip" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/switchTypeTipGroup"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        app:constraint_referenced_ids="tvSwitchTip,ivSwitchTipClose"
+        android:layout_height="wrap_content"/>
+
+    <ImageView
+        android:id="@+id/ivFloatingWindow"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginStart="15dp"
+        android:layout_marginTop="15dp"
+        android:src="@drawable/icon_call_floating_window"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/Android/call-ui/src/main/res/layout/view_p2p_video_call.xml
+++ b/Android/call-ui/src/main/res/layout/view_p2p_video_call.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2022 NetEase, Inc. All rights reserved.
+  ~ Use of this source code is governed by a MIT license that can be
+  ~ found in the LICENSE file.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/clRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/black"
+    tools:ignore="ContentDescription,SpUsage">
+
+    <!--视频通话远端用户视频画面-->
+    <com.netease.lava.nertc.sdk.video.NERtcVideoView
+        android:id="@+id/videoViewBig"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/ivBigVideoShade"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/black"
+        android:visibility="gone" />
+
+    <!--视频通话本地用户预览大视频画面-->
+    <com.netease.lava.nertc.sdk.video.NERtcVideoView
+        android:id="@+id/videoViewPreview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/ivBg"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
+    <!-- 视频呼叫页面顶部用户信息 start -->
+    <FrameLayout
+        android:id="@+id/flUserAvatar"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:layout_marginTop="50dp"
+        android:layout_marginEnd="18dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tvUserInnerAvatar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:textSize="25dp"
+            android:textStyle="bold" />
+
+        <ImageView
+            android:id="@+id/ivUserInnerAvatar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:src="@drawable/t_avchat_avatar_default" />
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/tvUserName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="30dp"
+        android:layout_marginEnd="10dp"
+        android:textColor="@color/colorWhite"
+        android:textSize="18dp"
+        app:layout_constraintEnd_toStartOf="@id/flUserAvatar"
+        app:layout_constraintTop_toTopOf="@id/flUserAvatar" />
+
+    <TextView
+        android:id="@+id/tvOtherCallTip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="30dp"
+        android:layout_marginEnd="10dp"
+        android:text="@string/ui_tip_waiting_to_accept_for_audio"
+        android:textColor="@color/colorWhite"
+        android:textSize="14dp"
+        app:layout_constraintEnd_toStartOf="@id/flUserAvatar"
+        app:layout_constraintTop_toBottomOf="@id/tvUserName" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/userInfoGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="flUserAvatar,tvUserName,tvOtherCallTip" />
+
+    <TextView
+        android:id="@+id/tvBigVideoCloseTip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/close_video_tip_bg"
+        android:padding="10dp"
+        android:text="@string/ui_tip_close_camera_by_other"
+        android:textColor="@color/color_white"
+        android:textSize="20sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <FrameLayout
+        android:id="@+id/fl_small_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="40dp"
+        android:layout_marginEnd="16dp">
+
+        <com.netease.lava.nertc.sdk.video.NERtcTextureView
+            android:id="@+id/videoViewSmall"
+            android:layout_width="90dp"
+            android:layout_height="160dp"/>
+
+        <ImageView
+            android:id="@+id/ivSmallVideoShade"
+            android:layout_width="90dp"
+            android:layout_height="160dp"
+            android:background="@color/black"
+            android:visibility="gone"/>
+
+        <TextView
+            android:id="@+id/tvSmallVideoCloseTip"
+            android:layout_width="90dp"
+            android:layout_height="160dp"
+            android:background="@drawable/close_video_tip_bg"
+            android:gravity="center"
+            android:padding="10dp"
+            android:text="@string/ui_tip_close_camera_by_other"
+            android:textColor="@color/color_white"
+            android:textSize="11sp"
+            android:visibility="gone"/>
+    </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/Android/call-ui/src/main/res/layout/view_permission_tip_layout.xml
+++ b/Android/call-ui/src/main/res/layout/view_permission_tip_layout.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@drawable/callkit_ui_permission_dialog_bg"
+    android:clickable="true"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tips_title"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:textColor="@color/black"
+        android:text="@string/ui_permission_dialog_title"
+        android:layout_marginStart="30dp"
+        android:layout_marginEnd="30dp"
+        android:layout_marginTop="20dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/tips"
+        android:layout_marginTop="12dp"
+        android:layout_marginStart="30dp"
+        android:layout_marginEnd="30dp"
+        android:layout_marginBottom="20dp"
+        android:textSize="15sp"
+        android:gravity="center"
+        android:textColor="#888888"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <View
+        android:background="#EEEEEE"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/negative_btn"
+            android:layout_marginTop="15dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="15dp"
+            android:gravity="center"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            android:textSize="15.55sp"
+            android:text="@string/ui_cancel"
+            android:layout_weight="0.5"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <View
+            android:background="#EEEEEE"
+            android:layout_width="0.5dp"
+            android:layout_height="match_parent"/>
+
+        <TextView
+            android:id="@+id/positive_btn"
+            android:layout_marginTop="15dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="15dp"
+            android:text="@string/ui_permission_dialog_positive_setting_text"
+            android:textSize="15.55sp"
+            android:textStyle="bold"
+            android:layout_weight="0.5"
+            android:textColor="#FF147AFF"
+            android:gravity="center"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+</LinearLayout>

--- a/Android/call-ui/src/main/res/values-en/strings.xml
+++ b/Android/call-ui/src/main/res/values-en/strings.xml
@@ -76,4 +76,21 @@
     <string name="user_join_group_call_with_user_count">There are %d people participating in the call.</string>
     <string name="ui_member_exceed_limit">currently supports call with up to 10 people</string>
 
+    <string name="ui_permission_dialog_title">Permission Request</string>
+    <string name="ui_permission_dialog_positive_setting_text">Go to Settings</string>
+    <string name="ui_float_permission_hint">Please enable both \"Background Pop-up\" and \"Display Overlay\" permissions</string>
+    <string name="ui_float_permission_hint_harmony">Please enable both \"Background Pop-up\" and \"Overlay\" permissions</string>
+
+    <string name="ui_permission_camera">Camera</string>
+    <string name="ui_permission_microphone">Microphone</string>
+    <string name="ui_permission_bluetooth">Bluetooth</string>
+    <string name="ui_permission_separator">,</string>
+    <string name="ui_permission_tips">Please turn on the %s permission first</string>
+    <string name="ui_permission_title">%s applies for access to the %s</string>
+    <string name="ui_permission_mic_reason">Needs access to your microphone, and it can be used for functions such as Audio/Video Call, Group Audio/Video Call etc.</string>
+    <string name="ui_permission_camera_reason">Needs access to your camera, and it can be used for functions such as Video Call, Group Video Call etc. For beauty filters to work, we will collect the facial information captured by your camera in real time to detect your facial features.</string>
+
+    <string name="ui_channel_description">Running</string>
+    <string name="ui_channel_name">Video Call Foreground Service</string>
+
 </resources>

--- a/Android/call-ui/src/main/res/values/strings.xml
+++ b/Android/call-ui/src/main/res/values/strings.xml
@@ -75,4 +75,22 @@
     <string name="tip_group_wait_to_accept">待接听</string>
     <string name="user_join_group_call_with_user_count">还有%d人参与通话</string>
     <string name="ui_member_exceed_limit">暂支持最多10人通话</string>
+
+    <string name="ui_permission_dialog_title">权限申请</string>
+    <string name="ui_permission_dialog_positive_setting_text">去设置</string>
+    <string name="ui_float_permission_hint">请同时打开\"后台弹出界面\"和\"显示悬浮窗\"权限</string>
+    <string name="ui_float_permission_hint_harmony">请同时打开\"后台弹窗\"和\"悬浮窗\"权限</string>
+
+    <string name="ui_permission_camera">摄像头</string>
+    <string name="ui_permission_microphone">麦克风</string>
+    <string name="ui_permission_bluetooth">蓝牙</string>
+    <string name="ui_permission_separator">、</string>
+    <string name="ui_permission_tips">请先打开%s权限</string>
+    <string name="ui_permission_title">%s申请获取%s权限</string>
+    <string name="ui_permission_camera_reason">需要访问您的相机权限，开启后用于视频通话、多人视频通话等功能，在您使用美颜功能时，我们会对您实时拍摄的面部的像素信息进行实时智能识别，在识别过程中会实时收集您面部的像素信息，以为您提供更好的美颜效果。</string>
+    <string name="ui_permission_mic_reason">需要访问您的麦克风权限，开启后用于语音通话、多人语音通话、视频通话、多人视频通话等功能，并且开启后录制的视频才会有声音。</string>
+
+    <string name="ui_channel_description">运行中</string>
+    <string name="ui_channel_name">音视频通话服务</string>
+
 </resources>

--- a/Android/gradle/libs.versions.toml
+++ b/Android/gradle/libs.versions.toml
@@ -13,10 +13,13 @@ androidGradlePlugin = "8.2.2"
 
 # Testing
 junit4 = "4.13.2"
+androidxTestExtJunit = "1.1.5"
+androidxTestEspresso = "3.5.1"
 
 # Networking
 retrofit = "2.9.0"
 okhttp = "4.12.0"
+gson = "2.10.1"
 
 # Image Loading
 glide = "4.13.1"
@@ -27,6 +30,8 @@ nertcVersion = "5.9.10"
 v2NimVersion = "10.9.45"
 alog = "1.1.1"
 commonUiVersion = "1.9.0"
+hawk = "1.7.13"
+androidxMultidex = "2.0.1"
 
 [libraries]
 # Android & Kotlin
@@ -38,6 +43,10 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "androidxRecyclerView" }
 androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "androidxViewPager2" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
+androidx-multidex = { group = "androidx.multidex", name = "multidex", version.ref = "androidxMultidex" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxTestEspresso" }
+androidx-test-espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "androidxTestEspresso" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
@@ -48,6 +57,7 @@ retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.r
 retrofit-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
 # Image Loading
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
@@ -56,6 +66,9 @@ glide-transformations = { group = "jp.wasabeef", name = "glide-transformations",
 # NetEase SDKs
 yunxin-kit-alog = { group = "com.netease.yunxin.kit", name = "alog", version.ref = "alog" }
 yunxin-common-ui = { group = "com.netease.yunxin.kit.common", name = "common-ui", version.ref = "commonUiVersion" }
+yunxin-kit-hawk = { group = "com.netease.yunxin.kit.hawk", name = "hawk", version.ref = "hawk" }
+yunxin-nertc-nenn = { group = "com.netease.yunxin", name = "nertc-nenn", version.ref = "nertcVersion" }
+yunxin-nertc-segment = { group = "com.netease.yunxin", name = "nertc-segment", version.ref = "nertcVersion" }
 
 [bundles]
 # Optional bundles for commonly used dependency groups

--- a/HarmonyOS/INTEGRATION_GUIDE.md
+++ b/HarmonyOS/INTEGRATION_GUIDE.md
@@ -1,0 +1,433 @@
+# NERTCCallKit HarmonyOS 集成开发指南
+
+本文档详细说明如何将 NERTCCallKit 集成到您的 HarmonyOS 项目中。
+
+## 目录
+
+- [前置准备](#前置准备)
+- [集成步骤](#集成步骤)
+- [初始化配置](#初始化配置)
+- [API 使用](#api-使用)
+- [UI 集成](#ui-集成)
+- [权限配置](#权限配置)
+- [高级功能](#高级功能)
+- [最佳实践](#最佳实践)
+
+## 前置准备
+
+### 1. 获取 APP_KEY
+
+1. 登录 [云信控制台](https://console.yunxin.163.com/)
+2. 创建应用或选择已有应用
+3. 在应用详情中获取 APP_KEY
+
+### 2. 准备账号系统
+
+NERTCCallKit 需要配合云信 IM SDK 使用，您需要：
+
+- 实现账号登录功能
+- 获取账号的 accid 和 token
+- 初始化 NIM SDK
+
+## 集成步骤
+
+### 步骤 1: 添加依赖
+
+在您的项目根目录的 `oh-package.json5` 中添加依赖：
+
+```json5
+{
+  "dependencies": {
+    "callkit": "file:../callkit",
+    "callkit_ui": "file:../callkit_ui"
+  }
+}
+```
+
+或者如果使用远程依赖：
+
+```json5
+{
+  "dependencies": {
+    "callkit": "^1.0.0",
+    "callkit_ui": "^1.0.0"
+  }
+}
+```
+
+### 步骤 2: 安装依赖
+
+```bash
+ohpm install
+```
+
+### 步骤 3: 配置 APP_KEY
+
+创建配置文件 `entry/src/main/ets/config/AppConfig.ets`：
+
+```typescript
+export class AppConfig {
+  private static readonly APP_KEY: string = "your app key";
+  
+  public static getAppKey(): string {
+    return AppConfig.APP_KEY;
+  }
+}
+```
+
+### 步骤 4: 配置权限
+
+在 `entry/src/main/module.json5` 中添加必要权限：
+
+```json5
+{
+  "module": {
+    "requestPermissions": [
+      {
+        "name": "ohos.permission.CAMERA",
+        "reason": "用于视频通话",
+        "usedScene": {
+          "abilities": ["EntryAbility"],
+          "when": "always"
+        }
+      },
+      {
+        "name": "ohos.permission.MICROPHONE",
+        "reason": "用于音频/视频通话",
+        "usedScene": {
+          "abilities": ["EntryAbility"],
+          "when": "always"
+        }
+      },
+      {
+        "name": "ohos.permission.KEEP_BACKGROUND_RUNNING",
+        "usedScene": {
+          "abilities": ["EntryAbility"],
+          "when": "always"
+        }
+      }
+    ]
+  }
+}
+```
+
+## 初始化配置
+
+### 1. 初始化 NIM SDK
+
+```typescript
+import { NIMInitializeOptions } from '@nimsdk/base';
+import { AppConfig } from './config/AppConfig';
+
+// 初始化 NIM SDK
+const initializeOptions: NIMInitializeOptions = {
+  appkey: AppConfig.getAppKey(),
+  logLevel: LogLevel.Debug,
+  isOpenConsoleLog: true
+};
+
+// 使用您的 NIM SDK 初始化方法
+nimRepository.initNim(initializeOptions);
+```
+
+### 2. 初始化 CallKit
+
+```typescript
+import { NECallUI } from 'callkit_ui';
+import { NESetupConfig } from 'callkit/src/main/ets/api/Models';
+
+// 创建配置
+const setupConfig: NESetupConfig = {
+  // 配置项
+};
+
+// 初始化 CallKit UI
+NECallUI.setup(setupConfig);
+```
+
+## API 使用
+
+### 发起通话
+
+```typescript
+import { NECallUI } from 'callkit_ui';
+import { NECallParam, NECallType } from 'callkit/src/main/ets/api/Models';
+
+// 创建通话参数
+const callParam: NECallParam = {
+  userId: 'target_user_id',  // 目标用户 ID
+  callType: NECallType.VIDEO, // 或 NECallType.AUDIO
+  // 其他参数...
+};
+
+// 发起通话
+NECallUI.startCall(callParam);
+```
+
+### 监听通话事件
+
+```typescript
+import { NECallUI } from 'callkit_ui';
+import { NECallDelegate } from 'callkit/src/main/ets/api/Models';
+
+// 实现回调接口
+class MyCallDelegate implements NECallDelegate {
+  onCallStart(): void {
+    console.log('通话开始');
+  }
+  
+  onCallEnd(info: NECallEndInfo): void {
+    console.log('通话结束', info);
+  }
+  
+  // 其他回调方法...
+}
+
+// 设置回调
+NECallUI.setCallDelegate(new MyCallDelegate());
+```
+
+### 接听通话
+
+当收到来电时，CallKit 会自动显示接听界面。您也可以通过代码接听：
+
+```typescript
+import { NECallUI } from 'callkit_ui';
+
+// 接听通话
+NECallUI.accept();
+```
+
+### 挂断通话
+
+```typescript
+import { NECallUI } from 'callkit_ui';
+
+// 挂断通话
+NECallUI.hangup();
+```
+
+## UI 集成
+
+### 方式一：使用默认 UI（推荐）
+
+CallKit 提供了完整的 UI 组件，可以直接使用：
+
+```typescript
+import { CallMainPage } from 'callkit_ui/src/main/ets/pages/CallMainPage';
+
+// 在路由中配置
+router.pushUrl({
+  url: 'pages/CallMainPage'
+});
+```
+
+### 方式二：自定义 UI
+
+如果需要对 UI 进行自定义，可以：
+
+1. 继承 `CallMainWidget` 组件
+2. 重写相关方法
+3. 自定义样式和布局
+
+```typescript
+import { CallMainWidget } from 'callkit_ui/src/main/ets/widget/CallMainWidget';
+
+@Component
+export struct MyCustomCallWidget extends CallMainWidget {
+  // 自定义实现
+}
+```
+
+## 权限配置
+
+### 动态申请权限
+
+在发起通话前，需要动态申请权限：
+
+```typescript
+import AbilityAccessCtrl, { Permissions } from '@ohos.abilityAccessCtrl';
+
+async function requestPermissions(isVideoCall: boolean): Promise<boolean> {
+  const context = getContext(this) as common.UIAbilityContext;
+  const atManager = abilityAccessCtrl.createAtManager();
+  
+  const permissions: Array<Permissions> = isVideoCall 
+    ? [Permissions.MICROPHONE, Permissions.CAMERA]
+    : [Permissions.MICROPHONE];
+  
+  try {
+    const result = await atManager.requestPermissionsFromUser(context, permissions);
+    return result.authResults.every(result => result === 0);
+  } catch (error) {
+    console.error('申请权限失败', error);
+    return false;
+  }
+}
+```
+
+## 高级功能
+
+### 1. 虚拟背景
+
+```typescript
+import { CallManager } from 'callkit_ui';
+
+// 启用虚拟背景
+CallManager.instance.enableVirtualBackground(true);
+```
+
+### 2. 画中画功能
+
+```typescript
+import { PipManager } from 'callkit_ui/src/main/ets/utils/PipManager';
+
+// 启动画中画
+PipManager.getInstance().startPip();
+```
+
+### 3. 通话设置
+
+```typescript
+import { CallSettingsManager } from 'entry/src/main/ets/manager/CallSettingsManager';
+
+const settingsManager = new CallSettingsManager();
+await settingsManager.loadSettings(context);
+
+// 应用设置
+const settings = settingsManager.getSettings();
+// 使用设置...
+```
+
+### 4. 自定义通话参数
+
+```typescript
+const callParam: NECallParam = {
+  userId: 'target_user_id',
+  callType: NECallType.VIDEO,
+  rtcChannelName: 'custom_channel_name',  // 自定义频道名
+  globalExtraCopy: 'custom_params',       // 自定义参数
+  // 其他参数...
+};
+```
+
+## 最佳实践
+
+### 1. 错误处理
+
+```typescript
+try {
+  await NECallUI.startCall(callParam);
+} catch (error) {
+  console.error('发起通话失败', error);
+  // 显示错误提示
+}
+```
+
+### 2. 状态管理
+
+建议使用全局状态管理来管理通话状态：
+
+```typescript
+import { CallState } from 'callkit_ui/src/main/ets/impl/CallState';
+
+// 监听状态变化
+const state = CallState.instance;
+// 使用状态...
+```
+
+### 3. 生命周期管理
+
+确保在应用退出时清理资源：
+
+```typescript
+aboutToDisappear(): void {
+  // 清理通话资源
+  NECallUI.cleanup();
+}
+```
+
+### 4. 网络状态处理
+
+监听网络状态变化，处理网络异常：
+
+```typescript
+import { network } from '@kit.NetworkKit';
+
+network.on('typeChange', (data) => {
+  if (data.type === network.NetworkType.NONE) {
+    // 网络断开，提示用户
+  }
+});
+```
+
+### 5. 后台运行
+
+配置后台运行以支持通话：
+
+在 `module.json5` 中配置：
+
+```json5
+{
+  "abilities": [
+    {
+      "name": "EntryAbility",
+      "backgroundModes": ["audioRecording", "audioPlayback"]
+    }
+  ]
+}
+```
+
+## 常见集成问题
+
+### 1. 模块找不到
+
+**问题**: `Cannot find module 'callkit'`
+
+**解决**: 检查 `oh-package.json5` 中的依赖配置，确保路径正确
+
+### 2. 权限被拒绝
+
+**问题**: 通话时提示权限不足
+
+**解决**: 
+- 检查 `module.json5` 中的权限声明
+- 确保动态申请权限
+- 检查系统设置中的权限状态
+
+### 3. 登录失败
+
+**问题**: 无法登录
+
+**解决**:
+- 检查 APP_KEY 是否正确
+- 检查账号和 Token 是否有效
+- 检查网络连接
+
+### 4. 通话无法建立
+
+**问题**: 发起通话后无法连接
+
+**解决**:
+- 检查双方是否都已登录
+- 检查网络连接
+- 检查防火墙设置
+- 查看日志定位问题
+
+## 示例代码
+
+完整示例请参考项目中的：
+
+- `entry/src/main/ets/pages/LoginPage.ets` - 登录示例
+- `entry/src/main/ets/pages/SingleCallPage.ets` - 通话示例
+- `entry/src/main/ets/pages/Index.ets` - 主页面示例
+
+## 技术支持
+
+- **文档中心**: [https://doc.yunxin.163.com/](https://doc.yunxin.163.com/)
+- **问题反馈**: 通过 GitHub Issues 反馈
+
+## 更新日志
+
+查看各版本的更新内容，确保使用最新功能。
+

--- a/HarmonyOS/PUSH_CONFIG_GUIDE.md
+++ b/HarmonyOS/PUSH_CONFIG_GUIDE.md
@@ -1,0 +1,623 @@
+# PushConfig 配置指南
+
+本文档介绍如何在呼叫（call）时设置 pushConfig（推送配置）。提供两种开发方式的示例代码：
+1. **基于 callkit 开发** - 直接使用底层 API
+2. **基于 callkit_ui 开发** - 使用 UI 组件封装
+
+## 目录
+
+- [功能说明](#功能说明)
+- [PushConfig 结构](#pushconfig-结构)
+- [基于 callkit 开发](#基于-callkit-开发)
+- [基于 callkit_ui 开发](#基于-callkit_ui-开发)
+- [PushPayload 格式说明](#pushpayload-格式说明)
+- [最佳实践](#最佳实践)
+- [常见问题](#常见问题)
+
+## 功能说明
+
+PushConfig 用于配置离线推送功能，当被叫用户不在线时，可以通过推送通知提醒用户接听通话。
+
+**主要功能**：
+- 控制是否启用推送
+- 自定义推送标题和内容
+- 传递自定义数据（payload）
+
+## PushConfig 结构
+
+```typescript
+export class NECallPushConfig {
+  pushEnabled: boolean = true;    // 是否启用推送（默认 true）
+  pushTitle?: string;              // 推送标题（可选）
+  pushContent?: string;            // 推送内容（可选）
+  pushPayload?: string;            // 推送自定义数据，JSON 字符串格式（可选）
+}
+```
+
+## 基于 callkit 开发
+
+如果您直接使用 `callkit` 模块进行开发，可以在创建 `NECallParam` 时设置 `pushConfig`。
+
+### 1. 基本使用
+
+```typescript
+import { NECallEngine } from 'callkit';
+import { NECallParam, NECallType, NECallPushConfig } from 'callkit';
+
+// 创建推送配置
+const pushConfig = new NECallPushConfig();
+pushConfig.pushEnabled = true;
+pushConfig.pushTitle = '视频通话邀请';
+pushConfig.pushContent = '张三邀请你进行视频通话';
+
+// 创建通话参数
+const callParam = new NECallParam('target_user_id', NECallType.VIDEO);
+callParam.pushConfig = pushConfig;
+
+// 发起通话
+const result = await NECallEngine.getInstance().call(callParam);
+```
+
+### 2. 完整示例
+
+```typescript
+import { NECallEngine } from 'callkit';
+import { NECallParam, NECallType, NECallPushConfig } from 'callkit';
+
+/**
+ * 通话管理类
+ */
+export class CallService {
+  /**
+   * 发起视频通话（带推送配置）
+   */
+  async startVideoCall(targetUserId: string, callerName: string): Promise<void> {
+    // 创建推送配置
+    const pushConfig = new NECallPushConfig();
+    pushConfig.pushEnabled = true;
+    pushConfig.pushTitle = `${callerName}的视频通话`;
+    pushConfig.pushContent = `${callerName}邀请你进行视频通话`;
+    
+    // 创建自定义 payload
+    const payload = {
+      userID: targetUserId,
+      callType: 'video',
+      timestamp: Date.now(),
+      customField1: 'value1'
+    };
+    pushConfig.pushPayload = JSON.stringify(payload);
+
+    // 创建通话参数
+    const callParam = new NECallParam(targetUserId, NECallType.VIDEO);
+    callParam.pushConfig = pushConfig;
+
+    // 发起通话
+    try {
+      const result = await NECallEngine.getInstance().call(callParam);
+      if (result.code === 0) {
+        console.info('通话发起成功');
+      } else {
+        console.error(`通话发起失败: ${result.message}`);
+      }
+    } catch (error) {
+      console.error('发起通话异常:', error);
+    }
+  }
+
+  /**
+   * 发起音频通话（带推送配置）
+   */
+  async startAudioCall(targetUserId: string, callerName: string): Promise<void> {
+    const pushConfig = new NECallPushConfig();
+    pushConfig.pushEnabled = true;
+    pushConfig.pushTitle = `${callerName}的语音通话`;
+    pushConfig.pushContent = `${callerName}邀请你进行语音通话`;
+
+    const callParam = new NECallParam(targetUserId, NECallType.AUDIO);
+    callParam.pushConfig = pushConfig;
+
+    await NECallEngine.getInstance().call(callParam);
+  }
+
+  /**
+   * 发起通话（不使用推送）
+   */
+  async startCallWithoutPush(targetUserId: string, callType: NECallType): Promise<void> {
+    const pushConfig = new NECallPushConfig();
+    pushConfig.pushEnabled = false;  // 禁用推送
+
+    const callParam = new NECallParam(targetUserId, callType);
+    callParam.pushConfig = pushConfig;
+
+    await NECallEngine.getInstance().call(callParam);
+  }
+}
+```
+
+### 3. 工具类封装
+
+```typescript
+import { NECallParam, NECallType, NECallPushConfig } from 'callkit';
+
+/**
+ * PushConfig 工具类
+ */
+export class PushConfigHelper {
+  /**
+   * 创建默认推送配置
+   */
+  static createDefault(callerName: string, callType: NECallType): NECallPushConfig {
+    const pushConfig = new NECallPushConfig();
+    pushConfig.pushEnabled = true;
+    
+    const typeString = callType === NECallType.VIDEO ? '视频' : '语音';
+    pushConfig.pushTitle = `${callerName}的${typeString}通话`;
+    pushConfig.pushContent = `${callerName}邀请你进行${typeString}通话`;
+    
+    return pushConfig;
+  }
+
+  /**
+   * 创建带自定义 payload 的推送配置
+   */
+  static createWithPayload(
+    callerName: string,
+    callType: NECallType,
+    customData: Record<string, any>
+  ): NECallPushConfig {
+    const pushConfig = this.createDefault(callerName, callType);
+    
+    // 构建 payload
+    const payload = {
+      userID: '',  // 会在 SDK 内部填充
+      ...customData
+    };
+    
+    pushConfig.pushPayload = JSON.stringify(payload);
+    return pushConfig;
+  }
+}
+
+// 使用示例
+function startCall(targetUserId: string): void {
+  // 方式1: 使用默认配置
+  const pushConfig = PushConfigHelper.createDefault('张三', NECallType.VIDEO);
+  
+  // 方式2: 使用自定义 payload
+  // const pushConfig = PushConfigHelper.createWithPayload(
+  //   '张三',
+  //   NECallType.VIDEO,
+  //   { customField1: 'value1', customField2: 'value2' }
+  // );
+
+  const callParam = new NECallParam(targetUserId, NECallType.VIDEO);
+  callParam.pushConfig = pushConfig;
+
+  NECallEngine.getInstance().call(callParam);
+}
+```
+
+### 4. 动态构建 PushConfig
+
+```typescript
+import { NECallParam, NECallType, NECallPushConfig } from 'callkit';
+
+/**
+ * 通话页面组件
+ */
+@Entry
+@Component
+export struct CallPage {
+  @State targetUserId: string = '';
+  @State callerName: string = '我';
+
+  /**
+   * 发起通话
+   */
+  async startCall(callType: NECallType): Promise<void> {
+    // 动态构建推送配置
+    const pushConfig = this.buildPushConfig(callType);
+    
+    const callParam = new NECallParam(this.targetUserId, callType);
+    callParam.pushConfig = pushConfig;
+
+    await NECallEngine.getInstance().call(callParam);
+  }
+
+  /**
+   * 构建推送配置
+   */
+  private buildPushConfig(callType: NECallType): NECallPushConfig {
+    const pushConfig = new NECallPushConfig();
+    
+    // 根据通话类型设置不同的推送内容
+    if (callType === NECallType.VIDEO) {
+      pushConfig.pushTitle = `${this.callerName}的视频通话邀请`;
+      pushConfig.pushContent = `${this.callerName}邀请你进行视频通话`;
+    } else {
+      pushConfig.pushTitle = `${this.callerName}的语音通话邀请`;
+      pushConfig.pushContent = `${this.callerName}邀请你进行语音通话`;
+    }
+    
+    // 添加自定义 payload
+    const payload = {
+      userID: this.targetUserId,
+      callerName: this.callerName,
+      callType: callType === NECallType.VIDEO ? 'video' : 'audio',
+      timestamp: Date.now()
+    };
+    pushConfig.pushPayload = JSON.stringify(payload);
+    
+    return pushConfig;
+  }
+}
+```
+
+## 基于 callkit_ui 开发
+
+如果您使用 `callkit_ui` 模块进行开发，可以通过 `NECallUI` API 来发起通话并设置 pushConfig。
+
+### 1. 基本使用
+
+```typescript
+import { NECallUI } from 'callkit_ui';
+import { NECallParam, NECallType, NECallPushConfig } from 'callkit';
+
+// 创建推送配置
+const pushConfig = new NECallPushConfig();
+pushConfig.pushEnabled = true;
+pushConfig.pushTitle = '视频通话邀请';
+pushConfig.pushContent = '张三邀请你进行视频通话';
+
+// 创建通话参数
+const callParam = new NECallParam('target_user_id', NECallType.VIDEO);
+callParam.pushConfig = pushConfig;
+
+// 发起通话
+const result = await NECallUI.getInstance().call(callParam);
+```
+
+### 2. 完整示例
+
+```typescript
+import { NECallUI } from 'callkit_ui';
+import { NECallParam, NECallType, NECallPushConfig } from 'callkit';
+
+/**
+ * 通话页面组件
+ */
+@Entry
+@Component
+export struct SingleCallPage {
+  @State targetUserId: string = '';
+  @State callerName: string = '我';
+
+  /**
+   * 发起视频通话
+   */
+  async startVideoCall(): Promise<void> {
+    const callParam = this.buildCallParam(NECallType.VIDEO);
+    await NECallUI.getInstance().call(callParam);
+  }
+
+  /**
+   * 发起音频通话
+   */
+  async startAudioCall(): Promise<void> {
+    const callParam = this.buildCallParam(NECallType.AUDIO);
+    await NECallUI.getInstance().call(callParam);
+  }
+
+  /**
+   * 构建通话参数（包含 PushConfig）
+   */
+  private buildCallParam(callType: NECallType): NECallParam {
+    const callParam = new NECallParam(this.targetUserId, callType);
+    
+    // 创建推送配置
+    const pushConfig = new NECallPushConfig();
+    pushConfig.pushEnabled = true;
+    
+    const typeString = callType === NECallType.VIDEO ? '视频' : '语音';
+    pushConfig.pushTitle = `${this.callerName}的${typeString}通话`;
+    pushConfig.pushContent = `${this.callerName}邀请你进行${typeString}通话`;
+    
+    // 可选：添加自定义 payload
+    const payload = {
+      userID: this.targetUserId,
+      callerName: this.callerName,
+      callType: callType === NECallType.VIDEO ? 'video' : 'audio'
+    };
+    pushConfig.pushPayload = JSON.stringify(payload);
+    
+    callParam.pushConfig = pushConfig;
+    
+    return callParam;
+  }
+}
+```
+
+### 3. 使用 CallManager（内部 API）
+
+```typescript
+import { CallManager } from 'callkit_ui/src/main/ets/impl/CallManager';
+import { NECallParam, NECallType, NECallPushConfig } from 'callkit';
+
+/**
+ * 通话服务类
+ */
+export class CallService {
+  /**
+   * 发起通话（使用 CallManager）
+   */
+  async startCall(targetUserId: string, callType: NECallType): Promise<void> {
+    // 创建推送配置
+    const pushConfig = new NECallPushConfig();
+    pushConfig.pushEnabled = true;
+    pushConfig.pushTitle = '通话邀请';
+    pushConfig.pushContent = '有人邀请你进行通话';
+
+    // 创建通话参数
+    const callParam = new NECallParam(targetUserId, callType);
+    callParam.pushConfig = pushConfig;
+
+    // 使用 CallManager 发起通话
+    await CallManager.instance.call(callParam);
+  }
+}
+```
+
+### 4. 实际使用示例
+
+```typescript
+import { NECallUI } from 'callkit_ui';
+import { NECallParam, NECallType, NECallPushConfig } from 'callkit';
+
+/**
+ * 通话服务类
+ */
+export class CallService {
+  /**
+   * 发起通话（带推送配置）
+   */
+  async startCall(
+    targetUserId: string,
+    callType: NECallType,
+    callerName: string
+  ): Promise<void> {
+    // 创建通话参数
+    const callParam = new NECallParam(targetUserId, callType);
+    
+    // 创建推送配置
+    const pushConfig = new NECallPushConfig();
+    pushConfig.pushEnabled = true;
+    
+    const typeString = callType === NECallType.VIDEO ? '视频' : '语音';
+    pushConfig.pushTitle = `${callerName}的${typeString}通话`;
+    pushConfig.pushContent = `${callerName}邀请你进行${typeString}通话`;
+    
+    // 可选：添加自定义 payload
+    const payload = {
+      userID: targetUserId,
+      callerName: callerName,
+      callType: callType === NECallType.VIDEO ? 'video' : 'audio',
+      timestamp: Date.now()
+    };
+    pushConfig.pushPayload = JSON.stringify(payload);
+    
+    callParam.pushConfig = pushConfig;
+
+    // 发起通话
+    await NECallUI.getInstance().call(callParam);
+  }
+}
+```
+
+## PushPayload 格式说明
+
+PushPayload 是一个 JSON 字符串，用于传递自定义数据。SDK 会自动添加一些内部字段。
+
+### 1. 基本格式
+
+```typescript
+const payload = {
+  userID: 'caller_user_id',  // 主叫用户ID（SDK 会自动填充）
+  customField1: 'value1',
+  customField2: 'value2',
+  // 注意：SDK 会在内部添加 NECallPushPayload 字段
+};
+
+const pushConfig = new NECallPushConfig();
+pushConfig.pushPayload = JSON.stringify(payload);
+```
+
+### 2. 完整示例
+
+```typescript
+// 创建自定义 payload
+const payload = {
+  userID: 'caller_123',           // 主叫用户ID
+  callType: 'video',               // 通话类型
+  timestamp: Date.now(),           // 时间戳
+  businessId: 'order_12345',       // 业务ID
+  customData: {                    // 自定义数据
+    from: 'home_page',
+    source: 'user_click'
+  }
+};
+
+const pushConfig = new NECallPushConfig();
+pushConfig.pushPayload = JSON.stringify(payload);
+```
+
+### 3. SDK 内部字段
+
+SDK 会在 payload 中自动添加 `NECallPushPayload` 字段，包含：
+
+```typescript
+{
+  userID: 'caller_user_id',
+  NECallPushPayload: {
+    callType: 1,              // 1=音频, 2=视频
+    displayName: '主叫名称',
+    userId: 'caller_user_id',
+    requestId: 'call_request_id'
+  },
+  // 您的自定义字段...
+}
+```
+
+## 最佳实践
+
+### 1. 使用默认推送配置
+
+如果不设置 pushConfig，SDK 会使用默认配置：
+
+```typescript
+// 不设置 pushConfig，使用默认值
+const callParam = new NECallParam(targetUserId, NECallType.VIDEO);
+// callParam.pushConfig 为 undefined，SDK 会使用默认配置
+await NECallEngine.getInstance().call(callParam);
+```
+
+### 2. 根据通话类型设置不同内容
+
+```typescript
+function createPushConfig(callType: NECallType, callerName: string): NECallPushConfig {
+  const pushConfig = new NECallPushConfig();
+  pushConfig.pushEnabled = true;
+  
+  if (callType === NECallType.VIDEO) {
+    pushConfig.pushTitle = `${callerName}的视频通话`;
+    pushConfig.pushContent = `${callerName}邀请你进行视频通话`;
+  } else {
+    pushConfig.pushTitle = `${callerName}的语音通话`;
+    pushConfig.pushContent = `${callerName}邀请你进行语音通话`;
+  }
+  
+  return pushConfig;
+}
+```
+
+### 3. 验证 PushPayload JSON 格式
+
+```typescript
+function createPushConfigWithPayload(customData: Record<string, any>): NECallPushConfig {
+  const pushConfig = new NECallPushConfig();
+  
+  try {
+    // 验证 JSON 格式
+    const payload = {
+      ...customData
+    };
+    pushConfig.pushPayload = JSON.stringify(payload);
+    
+    // 验证是否可以解析
+    JSON.parse(pushConfig.pushPayload);
+  } catch (error) {
+    console.error('PushPayload JSON 格式错误:', error);
+    // 使用空字符串或默认值
+    pushConfig.pushPayload = '';
+  }
+  
+  return pushConfig;
+}
+```
+
+### 4. 根据业务需求构建
+
+```typescript
+function buildCallParam(
+  targetUserId: string,
+  callType: NECallType,
+  callerName: string,
+  customPayload?: Record<string, any>
+): NECallParam {
+  const callParam = new NECallParam(targetUserId, callType);
+  
+  // 创建推送配置
+  const pushConfig = new NECallPushConfig();
+  pushConfig.pushEnabled = true;
+  
+  const typeString = callType === NECallType.VIDEO ? '视频' : '语音';
+  pushConfig.pushTitle = `${callerName}的${typeString}通话`;
+  pushConfig.pushContent = `${callerName}邀请你进行${typeString}通话`;
+  
+  // 如果有自定义 payload，添加
+  if (customPayload) {
+    const payload = {
+      userID: targetUserId,
+      ...customPayload
+    };
+    pushConfig.pushPayload = JSON.stringify(payload);
+  }
+  
+  callParam.pushConfig = pushConfig;
+  
+  return callParam;
+}
+```
+
+## 常见问题
+
+### 1. PushConfig 不生效
+
+**问题**: 设置了 pushConfig 但推送没有发送
+
+**解决**:
+- 检查 `pushEnabled` 是否为 `true`
+- 确保被叫用户确实不在线（在线时不会发送推送）
+- 检查推送服务是否配置正确
+- 查看日志确认 pushConfig 是否正确传递
+
+### 2. PushPayload 解析失败
+
+**问题**: PushPayload JSON 格式错误
+
+**解决**:
+- 确保 payload 是有效的 JSON 字符串
+- 使用 `JSON.stringify()` 和 `JSON.parse()` 验证格式
+- 避免在 payload 中包含循环引用
+
+### 3. 推送标题/内容为空
+
+**问题**: 推送通知显示为空
+
+**解决**:
+- 如果不设置 `pushTitle` 和 `pushContent`，SDK 会使用默认值
+- 确保设置的值不为空字符串
+- 检查设置是否正确保存和加载
+
+### 4. 自定义 Payload 字段丢失
+
+**问题**: 自定义的 payload 字段在接收端丢失
+
+**解决**:
+- 确保 payload 是有效的 JSON 对象
+- 避免使用 SDK 保留的字段名（如 `NECallPushPayload`）
+- 检查 payload 大小是否超过限制
+
+### 5. 推送配置不生效
+
+**问题**: 设置了 pushConfig 但推送没有发送
+
+**解决**:
+- 确保 `pushEnabled` 为 `true`
+- 检查被叫用户是否不在线（在线时不会发送推送）
+- 验证推送服务配置是否正确
+- 查看日志确认 pushConfig 是否正确传递
+
+## 示例代码位置
+
+完整示例代码请参考：
+
+- **PushConfig 构建**: `callkit/src/main/ets/impl/service/SignallingService.ets` (第 292-400 行)
+- **API 定义**: `callkit/src/main/ets/api/Models.ets` (第 67-72 行)
+- **使用示例**: `callkit/src/main/ets/impl/NECallEngineImpl.ets` (第 384-405 行)
+
+## 技术支持
+
+如有问题，请参考：
+- [云信文档中心](https://doc.yunxin.163.com/)
+- GitHub Issues
+

--- a/HarmonyOS/build-profile.json5
+++ b/HarmonyOS/build-profile.json5
@@ -4,9 +4,35 @@
     "products": [
       {
         "name": "default",
-        "signingConfig": "default",
-        "targetSdkVersion": "6.0.0(20)",
-        "compatibleSdkVersion": "6.0.0(20)",
+        "signingConfig": "debug",
+        "targetSdkVersion": "5.0.5(17)",
+        "compatibleSdkVersion": "5.0.1(13)",
+        "runtimeOS": "HarmonyOS",
+        "buildOption": {
+          "strictMode": {
+            "caseSensitiveCheck": true,
+            "useNormalizedOHMUrl": true
+          }
+        }
+      },
+      {
+        "name": "release",
+        "signingConfig": "release",
+        "targetSdkVersion": "5.0.5(17)",
+        "compatibleSdkVersion": "5.0.1(13)",
+        "runtimeOS": "HarmonyOS",
+        "buildOption": {
+          "strictMode": {
+            "caseSensitiveCheck": true,
+            "useNormalizedOHMUrl": true
+          }
+        }
+      },
+      {
+        "name": "debug",
+        "signingConfig": "debug",
+        "targetSdkVersion": "5.0.5(17)",
+        "compatibleSdkVersion": "5.0.1(13)",
         "runtimeOS": "HarmonyOS",
         "buildOption": {
           "strictMode": {

--- a/HarmonyOS/package-lock.json
+++ b/HarmonyOS/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "HarmonyOS",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
  - 升级 call/call-ui SDK 版本从 3.8.0 到 4.1.0
  - 重构 P2PCallActivity，将视频画面逻辑抽取到 P2PVideoCallLayout
  - 扩展 CallKitBridge 接口，新增音视频控制、悬浮窗、前台服务等能力
  - 引入 CallManager 统一管理通话操作
  - Fragment 基类由 BaseP2pCallFragment 迁移至 BaseOnTheCallFragment
  - 新增权限申请页面、AI 字幕组件和前台 Service
  - 日志框架从 ALog 切换到 XKitLog
  - 补充 proguard 混淆规则和多语言字符串资源